### PR TITLE
Added global params to the side of all pages and integrated them into…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,22 @@
 {
   "name": "heroic-frontend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heroic-frontend",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
+        "@joergdietrich/leaflet.terminator": "^1.1.0",
         "@mdi/font": "^7.4.47",
         "@vuepic/vue-datepicker": "^11.0.2",
+        "@vueuse/core": "^13.1.0",
         "echarts": "^5.6.0",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "pinia": "^3.0.1",
+        "vis-timeline": "^7.7.4",
         "vue": "^3.5.13",
         "vue-echarts": "^7.0.3",
         "vue-router": "^4.5.0"
@@ -539,6 +542,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1196,6 +1212,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@joergdietrich/leaflet.terminator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@joergdietrich/leaflet.terminator/-/leaflet.terminator-1.1.0.tgz",
+      "integrity": "sha512-Bq/dBECmVH6nf8V0zVSS7dUJA4bqe0Czl0DWzV1O1kTl5hMXGGc4EuyhTMft6KMLTU0GTLr4dvEa3YfXJWUUTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.2.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -1604,11 +1629,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1892,6 +1930,44 @@
         "vuetify": "^3.0.0"
       }
     },
+    "node_modules/@vueuse/core": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.1.0.tgz",
+      "integrity": "sha512-PAauvdRXZvTWXtGLg8cPUFjiZEddTqmogdwYpnn60t08AA5a8Q4hZokBnpTOnVNqySlFlTcRYIC8OqreV4hv3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.1.0",
+        "@vueuse/shared": "13.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.1.0.tgz",
+      "integrity": "sha512-+TDd7/a78jale5YbHX9KHW3cEDav1lz1JptwDvep2zSG8XjCsVE+9mHIzjTOaPbHUAk5XiE4jXLz51/tS+aKQw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.1.0.tgz",
+      "integrity": "sha512-IVS/qRRjhPTZ6C2/AM3jieqXACGwFZwWTdw5sNTSKk2m/ZpkuuN+ri+WCVUP8TqaKwJYt/KuMwmXspMAw8E6ew==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2106,6 +2182,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2162,6 +2255,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -3070,6 +3170,13 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keycharm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3184,6 +3291,16 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -3542,6 +3659,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/propagating-hammerjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-2.0.1.tgz",
+      "integrity": "sha512-PH3zG5whbSxMocphXJzVtvKr+vWAgfkqVvtuwjSJ/apmEACUoiw6auBAT5HYXpZOR0eGcTAfYG5Yl8h91O5Elg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.17"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3882,6 +4009,74 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vis-data": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.9.tgz",
+      "integrity": "sha512-COQsxlVrmcRIbZMMTYwD+C2bxYCFDNQ2EHESklPiInbD/Pk3JZ6qNL84Bp9wWjYjAzXfSlsNaFtRk+hO9yBPWA==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "vis-util": "^5.0.1"
+      }
+    },
+    "node_modules/vis-timeline": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-7.7.4.tgz",
+      "integrity": "sha512-JkL1Qf2lkXze7M+NjbUmGrlJtYqCKoP49PQ0GOPIayjj/sXNpTNuIPHkJASZu1SH6XlRBYfU0hev5rRsSErHOQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "moment": "^2.24.0",
+        "propagating-hammerjs": "^1.4.0 || ^2.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "vis-data": "^6.3.0 || ^7.0.0",
+        "vis-util": "^5.0.1",
+        "xss": "^1.0.0"
+      }
+    },
+    "node_modules/vis-util": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.7.tgz",
+      "integrity": "sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0"
+      }
     },
     "node_modules/vite": {
       "version": "6.2.5",
@@ -4241,6 +4436,23 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@joergdietrich/leaflet.terminator": "^1.1.0",
     "@mdi/font": "^7.4.47",
     "@vuepic/vue-datepicker": "^11.0.2",
+    "@vueuse/core": "^13.1.0",
     "echarts": "^5.6.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "pinia": "^3.0.1",
+    "vis-timeline": "^7.7.4",
     "vue": "^3.5.13",
     "vue-echarts": "^7.0.3",
     "vue-router": "^4.5.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,42 @@
 <script setup>
+import { onMounted } from 'vue';
 import NavBar from './components/global/NavBar.vue'
+import GlobalFilters from './components/global/GlobalFilters.vue';
+import { fetchApiCall } from '@/utils/api'
+import { useFiltersStore } from '@/stores/filters'
+
+
+const filtersStore = useFiltersStore()
+
+
+onMounted(async () => {
+  // Fetch the telescope options from the API to populate the telescope select field
+  const url = import.meta.env.VITE_HEROIC_API_URL + 'observatories' + '/?limit=1000';
+  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
+    let telescopes = {};
+    data.results.forEach(observatory => {
+      observatory.sites.forEach(site => {
+        site.telescopes.forEach(telescope => {
+          telescopes[telescope.id] = telescope;
+          telescopes[telescope.id]['observatory_name'] = observatory.name;
+          telescopes[telescope.id]['site_name'] = site.name;
+          telescopes[telescope.id]['weather_url'] = site.weather_url;
+          telescopes[telescope.id]['elevation'] = site.elevation;
+          telescopes[telescope.id]['timezone'] = site.timezone;
+        })
+      })
+    })
+    filtersStore.telescopes = telescopes;
+    filtersStore.filteredTelescopes = Object.values(telescopes);
+  }})
+})
 
 </script>
 
 <template>
   <v-app>
     <nav-bar />
+    <global-filters />
     <v-main>
       <router-view />
     </v-main>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -11,3 +11,7 @@ a,
     background-color: hsla(160, 100%, 37%, 0.2);
   }
 }
+
+.v-expansion-panel-text .v-expansion-panel-text__wrapper {
+  padding-top: 0px;
+}

--- a/src/components/TelescopeStatusTimeline.vue
+++ b/src/components/TelescopeStatusTimeline.vue
@@ -1,0 +1,216 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { fetchApiCall } from '@/utils/api'
+import { useFiltersStore } from '@/stores/filters'
+import { DataSet, Timeline } from 'vis-timeline/standalone';
+import 'vis-timeline/styles/vis-timeline-graph2d.css';
+
+
+const props = defineProps({
+  telescope: {
+    type: String,
+    required: true
+  }
+})
+
+const filtersStore = useFiltersStore()
+const timelineDiv = ref(null);
+const telescopeStatuses = ref([]);
+const telescopeDarkIntervals = ref({});
+var timeline = null;
+const options = {
+  groupOrder: 'id',
+  stack: false,
+  maxHeight: '450px',
+  minHeight: '120px',
+  width: '1160px',
+  align: 'left',
+  dataAttributes: ['toggle', 'html'],
+  selectable: false,
+  zoomKey: 'ctrlKey',
+  tooltip: {
+    overflowMethod: 'cap'
+  }
+};
+
+const start = computed(() => {
+  return filtersStore.queryParams.base.start || new Date(Date.now() - (3600 * 1000 * 24 * 7)).toISOString();
+})
+
+const startMinusOne = computed(() => {
+  return new Date(new Date(start.value).getTime() - (3600 * 1000 * 24)).toISOString();
+})
+
+const end = computed(() => {
+  return filtersStore.queryParams.base.end || new Date(Date.now() + (3600 * 1000 * 24)).toISOString();
+})
+
+const endPlusOne = computed(() => {
+  return new Date(new Date(end.value).getTime() + (3600 * 1000 * 24)).toISOString();
+})
+
+const timelineData = computed(() => {
+  let visData = new DataSet();
+  if (telescopeStatuses.value) {
+    var lastStatus;
+    // Statues are in a list ordered by soonest first
+    telescopeStatuses.value.forEach(status => {
+      if (lastStatus) {
+        visData.add({
+          group: 'status',
+          start: status.date,
+          end: lastStatus.date,
+          className: status.status,
+          title: '<h4>' + status.status + '</h4><br><p>' + (status.reason || '') + '</p>',
+          toggle: 'tooltip',
+          html: true,
+          type: 'range'
+        });
+      }
+      else {
+        visData.add({
+          group: 'status',
+          start: status.date,
+          end: end.value,
+          className: status.status,
+          title: '<h4>' + status.status + '</h4><br><p>' + (status.reason || '') + '</p>',
+          toggle: 'tooltip',
+          html: true,
+          type: 'range'
+        });
+      }
+      lastStatus = status;
+    })
+  }
+  if (telescopeDarkIntervals.value && telescopeDarkIntervals.value[props.telescope]) {
+    let sunUpStart = null;
+    telescopeDarkIntervals.value[props.telescope].forEach(interval => {
+      if (sunUpStart) {
+        let statusItem = {
+          group: 'status',
+          start: sunUpStart,
+          end: interval[0],
+          className: 'sun-up',
+          title: 'Sun up',
+          toggle: 'tooltip',
+          type: 'background'
+        };
+        let visItem = { ...statusItem };
+        visData.add(statusItem);
+        if (filtersStore.visibilityResults && filtersStore.visibilityResults[props.telescope]) {
+          visItem['group'] = 'visibility';
+          visData.add(visItem);
+        }
+      }
+      sunUpStart = interval[1];
+    })
+
+  }
+  if (filtersStore.visibilityResults && filtersStore.visibilityResults[props.telescope]) {
+    filtersStore.visibilityResults[props.telescope].forEach(visibleRange => {
+      visData.add({
+        group: 'visibility',
+        className: 'VISIBLE',
+        start: visibleRange[0],
+        end: visibleRange[1],
+        title: 'Visible',
+        type: 'range'
+      });
+    })
+  }
+  return visData;
+})
+
+const timelineGroups = computed(() => {
+  let plotGroups = new DataSet();
+  if (telescopeStatuses.value){
+    plotGroups.add({
+      id: 'status',
+      content: 'Status',
+      title: 'status'
+    });
+  }
+  if (filtersStore.visibilityResults && filtersStore.visibilityResults[props.telescope]) {
+    plotGroups.add({
+      id: 'visibility',
+      content: 'Target Visibility',
+      title: 'visibility'
+    });
+  }
+  return plotGroups;
+})
+
+async function loadTelescopeStatus () {
+  const url = import.meta.env.VITE_HEROIC_API_URL + 'telescope-statuses' + '/?limit=1000&telescope=' + props.telescope + '&start=' + start.value + '&end=' + end.value;
+  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
+    telescopeStatuses.value = data.results;
+  }})
+}
+
+async function loadTelescopeDarkIntervals () {
+  const url = import.meta.env.VITE_HEROIC_API_URL + 'telescopes/' + props.telescope + '/dark_intervals/?start=' + startMinusOne.value + '&end=' + endPlusOne.value;
+  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
+    telescopeDarkIntervals.value = data;
+  }})
+}
+
+function timelineSetup() {
+  timeline = new Timeline(timelineDiv.value, new DataSet([]), options);
+}
+
+onMounted(async () => {
+  timelineSetup();
+})
+
+watch(() => filtersStore.$state.visibilityResults, async () => {
+  await loadTelescopeStatus();
+  await loadTelescopeDarkIntervals();
+  timeline.setGroups(new DataSet([]));
+  timeline.setItems(new DataSet([]));
+  timeline.setGroups(timelineGroups.value);
+  timeline.setItems(timelineData.value);
+  timeline.setWindow(start.value, end.value);
+}, {immediate: true})
+
+watch(() => filtersStore.$state.visibilityErrors, async () => {
+  if (Object.keys(filtersStore.$state.visibilityErrors).length > 0){
+    await loadTelescopeStatus();
+    await loadTelescopeDarkIntervals();
+    timeline.setGroups(new DataSet([]));
+    timeline.setItems(new DataSet([]));
+    timeline.setGroups(timelineGroups.value);
+    timeline.setItems(timelineData.value);
+  }
+})
+
+</script>
+<template>
+  <div ref="timelineDiv"></div>
+</template>
+<style>
+.vis-time-axis .vis-text {
+  color: #b3b3b3 !important;
+}
+.vis-labelset .vis-label {
+  color: #b3b3b3 !important;
+}
+.vis-item.VISIBLE {
+  background-color: rgb(185, 115, 234);
+  border-color: rgb(167, 71, 234);
+}
+.vis-item.AVAILABLE {
+  background-color: lightblue;
+  border-color: lightblue;
+}
+.vis-item.UNAVAILABLE {
+  background-color: lightcoral;
+  border-color: lightcoral;
+}
+.vis-item.SCHEDULABLE {
+  background-color: lightgreen;
+  border-color: lightgreen;
+}
+.vis-item.sun-up {
+  background-color: lightyellow !important;
+}
+</style>

--- a/src/components/global/GlobalFilters.vue
+++ b/src/components/global/GlobalFilters.vue
@@ -1,0 +1,602 @@
+<script setup>
+import { ref, computed } from 'vue'
+import DatePicker from '@vuepic/vue-datepicker';
+import { useFiltersStore } from '@/stores/filters'
+import { fetchApiCall } from '@/utils/api'
+import TelescopeSelect from './TelescopeSelect.vue'
+import { watchDebounced } from '@vueuse/core';
+
+const drawer = ref(true)
+const rail = ref(true)
+const searchTargetErrors = ref();
+const searchTargetSuccess = ref();
+const filtersStore = useFiltersStore()
+const minorPlanetFields = ['epoch_of_elements', 'orbital_inclination', 'longitude_of_ascending_node', 'argument_of_perihelion', 'mean_distance', 'eccentricity', 'mean_anomaly']
+const cometFields = ['epoch_of_elements', 'orbital_inclination', 'longitude_of_ascending_node', 'argument_of_perihelion', 'perihelion_distance', 'eccentricity', 'epoch_of_perihelion']
+const majorPlanetFields = ['epoch_of_elements', 'orbital_inclination', 'longitude_of_ascending_node', 'argument_of_perihelion', 'mean_distance', 'eccentricity', 'mean_anomaly', 'daily_motion']
+
+function setDateRange(offset_start, offset_end) {
+  filtersStore.queryParams.base.start = new Date(Date.now() + (3600 * 1000 * 24 * offset_start)).toISOString();
+  filtersStore.queryParams.base.end = new Date(Date.now() + (3600 * 1000 * 24 * offset_end)).toISOString();
+}
+
+function fillInTarget(targetData) {
+  filtersStore.queryParams.siderealTarget.ra = targetData.ra_d || targetData.ra || null
+  filtersStore.queryParams.siderealTarget.dec = targetData.dec_c || targetData.dec || null
+  filtersStore.queryParams.siderealTarget.proper_motion_ra = targetData.pmra || null
+  filtersStore.queryParams.siderealTarget.proper_motion_dec = targetData.pmdec || null
+  filtersStore.queryParams.siderealTarget.parallax = targetData.plx_value || null
+  filtersStore.queryParams.nonSiderealTarget.epoch_of_elements = targetData.epoch_jd ? targetData.epoch_jd - 2400000.5 : null;
+  filtersStore.queryParams.nonSiderealTarget.longitude_of_ascending_node = targetData.ascending_node || null;
+  filtersStore.queryParams.nonSiderealTarget.orbital_inclination = targetData.inclination || null;
+  filtersStore.queryParams.nonSiderealTarget.argument_of_perihelion = targetData.argument_of_perihelion || null;
+  filtersStore.queryParams.nonSiderealTarget.eccentricity = targetData.eccentricity || null;
+  filtersStore.queryParams.nonSiderealTarget.mean_distance = targetData.semimajor_axis || null;
+  filtersStore.queryParams.nonSiderealTarget.mean_anomaly = targetData.mean_anomaly || null;
+  filtersStore.queryParams.nonSiderealTarget.daily_motion = targetData.mean_daily_motion || null;
+  filtersStore.queryParams.nonSiderealTarget.perihelion_distance = targetData.perihelion_distance || null;
+  filtersStore.queryParams.nonSiderealTarget.epoch_of_perihelion = targetData.perihelion_date_jd ? targetData.perihelion_date_jd - 2400000.5 : null;
+}
+
+function clearTargetErrors() {
+  searchTargetErrors.value = null;
+  searchTargetSuccess.value = undefined;
+}
+
+function onChangeTargetType() {
+  // Reset the target fields to null and remove any target from the search bar when switching target types
+  filtersStore.targetName = null;
+  if(filtersStore.targetType == 'SIDEREAL') {
+    filtersStore.nonSiderealType = null;
+  }
+  else {
+    filtersStore.nonSiderealType = 'MPC_MINOR_PLANET';
+  }
+  clearTargetErrors();
+  fillInTarget({});
+}
+
+async function callSearchTarget () {
+  // search for target parameters from simbad2k service and prefill the fields if found
+  searchTargetErrors.value = null;
+  let url = import.meta.env.VITE_SIMBAD2K_API_URL + filtersStore.targetName + '?target_type=' + filtersStore.targetType;
+  if (filtersStore.targetType == 'NON_SIDEREAL') {
+    url = url + '&scheme=' + filtersStore.nonSiderealType;
+  }
+  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
+    fillInTarget(data);
+    if (data.error) {
+      // In this case, the API has not found a result, so inform the user of that
+      searchTargetErrors.value = data.error;
+    }
+    else {
+      searchTargetSuccess.value = 'Found target:' + data.name;
+    }
+  }, failCallback: (response) => {
+    let error = response.error || response;
+    searchTargetErrors.value = error;
+    console.error('Failed to get target details for ' + searchTarget.value + ' from simbad2k: ' + error);
+  }})
+}
+
+const dateString = computed(() => {
+  var ds = '';
+  if (filtersStore.queryParams.base.start) {
+    ds += filtersStore.queryParams.base.start.split('.')[0].replace('T', ' ');
+  }
+  ds += ' - ';
+  if (filtersStore.queryParams.base.end) {
+    ds += filtersStore.queryParams.base.end.split('.')[0].replace('T', ' ');
+  }
+  return ds;
+})
+
+const dateClass = computed(() => {
+  if (filtersStore.queryParams.base.start && filtersStore.queryParams.base.end) {
+    return 'fields-complete';
+  }
+  return 'fields-error';
+})
+
+const targetString = computed(() => {
+  var ts = '';
+  if (targetClass.value == 'fields-error') {
+    ts += 'No target specified';
+  }
+  else{
+    if (filtersStore.targetName && searchTargetSuccess.value) {
+      ts += filtersStore.targetName + ': ';
+    }
+    if (filtersStore.targetType == 'SIDEREAL'){
+      ts += filtersStore.queryParams.siderealTarget.ra + ' ra, ' + filtersStore.queryParams.siderealTarget.dec + ' dec';
+    }
+    else {
+      ts += filtersStore.nonSiderealType;
+    }
+  }
+  return ts;
+})
+
+const targetClass = computed(() => {
+  if (filtersStore.targetType == 'SIDEREAL'){
+    if (filtersStore.queryParams.siderealTarget.ra && filtersStore.queryParams.siderealTarget.dec) {
+      return 'fields-complete';
+    }
+  }
+  else{
+    var fields = [];
+    if (filtersStore.nonSiderealType == 'MPC_MINOR_PLANET') {
+      fields = minorPlanetFields;
+    }
+    else if (filtersStore.nonSiderealType == 'MPC_COMET') {
+      fields = cometFields;
+    }
+    else if (filtersStore.nonSiderealType == 'JPL_MAJOR_PLANET'){
+      fields = majorPlanetFields;
+    }
+    if (fields.every(field => filtersStore.queryParams.nonSiderealTarget[field] != null)) {
+      return 'fields-complete';
+    }
+  }
+  return 'fields-error';
+})
+
+const constraintsString = computed(() => {
+  var cs = '';
+  if (filtersStore.queryParams.base.max_airmass){
+    cs += filtersStore.queryParams.base.max_airmass.toFixed(1) + ' airmass; ';
+  }
+  if (filtersStore.queryParams.base.max_lunar_phase){
+    cs += filtersStore.queryParams.base.max_lunar_phase.toFixed(1);
+  }
+  if (filtersStore.queryParams.base.min_lunar_distance != 0) {
+    cs += ' / ' + filtersStore.queryParams.base.min_lunar_distance.toFixed(1);
+  }
+  cs += ' lunar phase'
+  if (filtersStore.queryParams.base.min_lunar_distance != 0) {
+    cs += ' / distance';
+  }
+  return cs;
+})
+
+const telescopesString = computed(() => {
+  if (filtersStore.queryParams.base.telescopes == null || filtersStore.queryParams.base.telescopes.length == 0){
+    return 'All Telescopes';
+  }
+  else {
+    return filtersStore.queryParams.base.telescopes.length.toString() + ' / ' + Object.keys(filtersStore.telescopes).length.toString() + ' Telescopes selected';
+  }
+})
+
+watchDebounced(() => filtersStore.$state.queryParams, () => {
+  if (dateClass.value == 'fields-complete' && targetClass.value == 'fields-complete') {
+    filtersStore.queryVisibilityAndAirmass();
+  }
+}, { debounce: 500, deep: true})
+
+
+</script>
+
+<template>
+  <v-navigation-drawer
+    v-model="drawer"
+    :rail="rail"
+    :location="$vuetify.display.mobile ? 'bottom' : undefined"
+    width="512"
+    permanent
+    @click="rail = false"
+  >
+    <v-list-item variant="outlined" nav>
+      <v-list-item-title>
+        <v-row>
+          <v-col cols="3" style="font-size:1.2rem;">Filters</v-col>
+          <v-col cols="3" offset="1" style="min-height: 44px;" v-if="!rail">
+            Visibility:
+            <v-progress-circular v-if="filtersStore.loadingVisibility" class="ml-1" color="primary" size="18" indeterminate></v-progress-circular>
+            <v-icon v-else-if="filtersStore.visibilityResults" color="green-darken-2" icon="mdi-checkbox-outline" size="18"></v-icon>
+            <v-icon v-else-if="Object.keys(filtersStore.visibilityErrors).length" color="red-darken-2" icon="mdi-close-box-outline" size="18" v-tooltip="JSON.stringify(filtersStore.visibilityErrors)"></v-icon>
+            <v-icon v-else icon="mdi-checkbox-blank-outline" size="18"></v-icon>
+          </v-col>
+          <v-col cols="3" offset="1" style="min-height: 44px;" v-if="!rail">
+            Airmass:
+            <v-progress-circular v-if="filtersStore.loadingAirmass" class="ml-1" color="primary" size="18" indeterminate></v-progress-circular>
+            <v-icon v-else-if="filtersStore.airmassResults" color="green-darken-2" icon="mdi-checkbox-outline" size="18"></v-icon>
+            <v-icon v-else-if="Object.keys(filtersStore.airmassErrors).length" color="red-darken-2" icon="mdi-close-box-outline" size="18" v-tooltip="JSON.stringify(filtersStore.airmassErrors)"></v-icon>
+            <v-icon v-else icon="mdi-checkbox-blank-outline" size="18"></v-icon>
+          </v-col>
+        </v-row>
+      </v-list-item-title>
+      <template v-slot:append>
+        <v-btn
+          class="menu-chevron"
+          :icon="rail ? 'mdi-chevron-right': 'mdi-chevron-left'"
+          variant="text"
+          @click.stop="rail = !rail"
+        ></v-btn>
+      </template>
+    </v-list-item>
+    <v-expansion-panels v-if="!rail">
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <v-row>
+            <v-col cols="3">
+              <p>Date Range:</p>
+            </v-col>
+            <v-col cols="9" v-if="filtersStore.queryParams.base.start || filtersStore.queryParams.base.end">
+              <p :class="dateClass">{{ dateString }}</p>
+            </v-col>
+          </v-row>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text class="filter-panel">
+          <v-btn-group class="mt-2" variant="outlined" divided>
+            <v-btn value="plus1day" @click="setDateRange(0, 1)">Next Day</v-btn>
+            <v-btn value="plus7day" @click="setDateRange(0, 7)">Next Week</v-btn>
+            <v-btn value="last1day" @click="setDateRange(-1, 0)">Past Day</v-btn>
+            <v-btn value="last7day" @click="setDateRange(-7, 0)">Past Week</v-btn>
+          </v-btn-group>
+          <div class="datepicker-group mt-3">
+            <v-label v-if="filtersStore.queryParams.base.start" id="start-dp-label" class="datepicker-label">Start Date</v-label> 
+            <DatePicker v-model="filtersStore.queryParams.base.start" id="start-dt-picker" model-type="iso" placeholder="Start Date" label="Start" required dark></DatePicker>
+          </div>
+          <div class="datepicker-group mt-3">
+            <v-label v-if="filtersStore.queryParams.base.end" id="end-dp-label" class="datepicker-label">End Date</v-label> 
+            <DatePicker v-model="filtersStore.queryParams.base.end" model-type="iso" placeholder="End Date" required dark></DatePicker>
+          </div>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <v-row>
+            <v-col cols="3">
+              <p>Target:</p>
+            </v-col>
+            <v-col cols="9">
+              <p :class="targetClass">{{ targetString }}</p>
+            </v-col>
+          </v-row>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text class="filter-panel">
+          <v-row>
+            <v-col class="pr-0 pl-0" cols="6">
+              <v-btn-toggle class="mt-4" v-model="filtersStore.targetType" color="deep-purple-accent-4" density="compact" rounded="0" group mandatory style="height:66px;" @update:modelValue="onChangeTargetType">
+                <v-btn value="SIDEREAL">Sidereal</v-btn>
+                <v-btn value="NON_SIDEREAL">Non-Sidereal</v-btn>
+              </v-btn-toggle>
+            </v-col>
+            <v-col class="pr-0 pl-0" cols="6">
+              <v-btn-toggle class="mt-4 button-stack" :disabled="filtersStore.targetType=='SIDEREAL'" v-model="filtersStore.nonSiderealType" color="deep-purple-accent-4" rounded="0" group>
+                <v-btn value="MPC_MINOR_PLANET" size="large">MPC Minor Planet</v-btn>
+                <v-btn value="MPC_COMET" size="large">MPC Comet</v-btn>
+                <v-btn value="JPL_MAJOR_PLANET" size="large">JPL Major Planet</v-btn>
+              </v-btn-toggle>
+            </v-col>
+          </v-row>
+          <v-text-field
+            class="mt-4"
+            variant="outlined"
+            label="Prefill Target"
+            v-model="filtersStore.targetName"
+            :error-messages="searchTargetErrors"
+            :base-color="searchTargetSuccess ? 'success': undefined"
+            :color="searchTargetSuccess ? 'success': undefined"
+            :messages="searchTargetSuccess"
+            @input="clearTargetErrors"
+          >
+            <template v-slot:append-inner>
+              <v-btn :disabled="!filtersStore.targetName" @click="callSearchTarget">Search</v-btn>
+            </template>
+          </v-text-field>
+          <div v-if="filtersStore.targetType=='SIDEREAL'" class="mt-4">
+            <v-number-input
+              label="Right Ascension (decimal degrees)"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.siderealTarget.ra"
+              :min="0"
+              :max="360"
+              :precision="9"
+              :error-messages="filtersStore.visibilityErrors.ra"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Declination (decimal degrees)"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.siderealTarget.dec"
+              :min="-90"
+              :max="90"
+              :precision="9"
+              :error-messages="filtersStore.visibilityErrors.dec"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Proper Motion RA (mas/yr)"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.siderealTarget.proper_motion_ra"
+              :min="-20000"
+              :max="20000"
+              :precision="9"
+              :error-messages="filtersStore.visibilityErrors.proper_motion_ra"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Proper Motion Dec (mas/yr)"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.siderealTarget.proper_motion_dec"
+              :min="-20000"
+              :max="20000"
+              :precision="9"
+              :error-messages="filtersStore.visibilityErrors.proper_motion_dec"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Epoch"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.siderealTarget.epoch"
+              :min="1900"
+              :max="2100"
+              :precision="2"
+              :error-messages="filtersStore.visibilityErrors.epoch"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Parallax (mas)"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.siderealTarget.parallax"
+              :min="-2000"
+              :max="2000"
+              :precision="2"
+              :error-messages="filtersStore.visibilityErrors.parallax"
+            >
+            </v-number-input>
+          </div>
+          <div v-if="filtersStore.targetType=='NON_SIDEREAL'" class="mt-4">
+            <v-number-input
+              class="mt-2"
+              label="Epoch of Elements"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.epoch_of_elements"
+              :min="10000"
+              :max="100000"
+              :precision="1"
+              :error-messages="filtersStore.visibilityErrors.epoch_of_elements"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Orbital Inclination"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.orbital_inclination"
+              :min="0"
+              :max="180"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.orbital_inclination"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Longitude of Ascending Node"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.longitude_of_ascending_node"
+              :min="0"
+              :max="360"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.longitude_of_ascending_node"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Argument of Perihelion"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.argument_of_perihelion"
+              :min="0"
+              :max="360"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.argument_of_perihelion"
+            >
+            </v-number-input>
+            <v-number-input
+              class="mt-2"
+              label="Eccentricity"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.eccentricity"
+              :min="0"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.eccentricity"
+            >
+            </v-number-input>
+            <v-number-input
+              v-if="filtersStore.nonSiderealType!='MPC_COMET'"
+              class="mt-2"
+              label="Mean Distance"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.mean_distance"
+              :min="0"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.mean_distance"
+            >
+            </v-number-input>
+            <v-number-input
+              v-if="filtersStore.nonSiderealType=='MPC_COMET'"
+              class="mt-2"
+              label="Perihelion Distance"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.perihelion_distance"
+              :min="0"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.perihelion_distance"
+            >
+            </v-number-input>
+            <v-number-input
+              v-if="filtersStore.nonSiderealType!='MPC_COMET'"
+              class="mt-2"
+              label="Mean Anomaly"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.mean_anomaly"
+              :min="0"
+              :max="360"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.mean_anomaly"
+            >
+            </v-number-input>
+            <v-number-input
+              v-if="filtersStore.nonSiderealType=='MPC_COMET'"
+              class="mt-2"
+              label="Epoch of Perihelion"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.epoch_of_perihelion"
+              :min="361"
+              :max="240000"
+              :precision="7"
+              :error-messages="filtersStore.visibilityErrors.epoch_of_perihelion"
+            >
+            </v-number-input>
+            <v-number-input
+              v-if="filtersStore.nonSiderealType=='JPL_MAJOR_PLANET'"
+              class="mt-2"
+              label="Daily Motion"
+              variant="outlined"
+              density="compact"
+              control-variant="hidden"
+              v-model="filtersStore.queryParams.nonSiderealTarget.daily_motion"
+              :min="0"
+              :precision="17"
+              :error-messages="filtersStore.visibilityErrors.daily_motion"
+            >
+            </v-number-input>
+          </div>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <v-row>
+            <v-col cols="3">
+              <p>Constraints:</p>
+            </v-col>
+            <v-col cols="9">
+              <p class="fields-complete">{{ constraintsString }}</p>
+            </v-col>
+          </v-row>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text class="filter-panel">
+          <v-number-input
+            class="mt-2"
+            label="Max Airmass"
+            control-variant="stacked"
+            v-model="filtersStore.queryParams.base.max_airmass"
+            :min="1"
+            :max="10"
+            :step="0.1"
+            :precision="1"
+          >
+          </v-number-input>
+          <v-number-input
+            label="Max Lunar Phase"
+            control-variant="stacked"
+            v-model="filtersStore.queryParams.base.max_lunar_phase"
+            :min="0"
+            :max="1"
+            :step="0.1"
+            :precision="1"
+          >
+          </v-number-input>
+          <v-number-input
+            label="Min Lunar Distance"
+            control-variant="stacked"
+            v-model="filtersStore.queryParams.base.min_lunar_distance"
+            :min="0"
+            :max="180"
+            :step="1"
+          >
+          </v-number-input>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <v-row>
+            <v-col cols="3">
+              <p>Telescopes:</p>
+            </v-col>
+            <v-col cols="9">
+              <p class="fields-complete">{{ telescopesString }}</p>
+            </v-col>
+          </v-row>        
+        </v-expansion-panel-title>
+        <v-expansion-panel-text class="filter-panel">
+          <telescope-select></telescope-select>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </v-navigation-drawer>
+</template>
+<style scoped>
+
+.menu-chevron {
+  left: -6px;
+}
+
+.fields-complete {
+  color: darkcyan;
+}
+
+.fields-error {
+  color: red;
+}
+
+.filter-panel {
+  background-color: rgb(18, 18, 18);
+}
+
+.datepicker-group {
+  position: relative;
+}
+
+.button-stack {
+  flex-direction: column;
+  padding-left:12px;
+  height: auto !important;
+}
+
+.datepicker-label {
+  z-index: 2;
+  position:absolute;
+  font-size:small;
+  top:-12px;
+  left: 8px;
+  background-color: var(--vt-c-black);
+}
+
+</style>

--- a/src/components/global/NavBar.vue
+++ b/src/components/global/NavBar.vue
@@ -4,42 +4,63 @@ import { RouterLink } from 'vue-router'
 
 <template>
   <v-app-bar>
-    <v-app-bar-title>HEROIC</v-app-bar-title>
+    <v-app-bar-title>
+      HER
+      <img
+        class="scimma-o"
+        src="https://scimma.org/static/imgs/logos/logo_transparent.png"
+        height="28px"
+        width="28px">
+      </img>
+      IC
+    </v-app-bar-title>
     <template v-slot:append>
       <router-link
         to="/"
         class="navbar-item"
       >
+        <v-icon class="pr-2 pb-1" icon="mdi-home" size="small"></v-icon>
         Home
       </router-link>
       <router-link
         to="/visibility"
         class="navbar-item"
       >
+        <v-icon class="pr-2 pb-1" icon="mdi-eye-outline" size="small"></v-icon>
         Target Visibility
       </router-link>
       <router-link
         to="/telescopes"
         class="navbar-item"
       >
+        <v-icon class="pr-2 pb-1" icon="mdi-telescope" size="small"></v-icon>
         Telescopes
       </router-link>
       <router-link
         to="/instruments"
         class="navbar-item"
       >
+        <v-icon class="pr-2 pb-1" icon="mdi-camera" size="small"></v-icon>
         Instruments
       </router-link>
       <router-link
         to="/about"
         class="navbar-item"
       >
+        <v-icon class="pr-2 pb-1" icon="mdi-help" size="small"></v-icon>
         About
       </router-link>
     </template>
   </v-app-bar>
 </template>
 <style scoped>
+
+.scimma-o {
+  position: relative;
+  top: 6px;
+  margin-left: -4px;
+  margin-right: -4px;
+}
 
 .navbar-item {
   width: 200px;

--- a/src/components/global/TelescopeSelect.vue
+++ b/src/components/global/TelescopeSelect.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useFiltersStore } from '@/stores/filters'
+
+const filtersStore = useFiltersStore()
+const selectAllBtnStates = ref({})
+const indeterminateStates = ref({})
+
+
+const telescopesByObservatory = computed(() => {
+  if (filtersStore.telescopes){
+    let telescopes = {};
+    Object.values(filtersStore.telescopes).forEach(telescope => {
+      let observatory = telescope.id.split('.')[0] + ': ' + telescope.observatory_name;
+      let site = telescope.id.split('.')[1] + ': ' + telescope.site_name;
+      if (!(observatory in telescopes)){
+        telescopes[observatory] = {};
+      }
+      if (!(site in telescopes[observatory])) {
+        telescopes[observatory][site] = [];
+      }
+      telescopes[observatory][site].push({
+        'id': telescope.id,
+        'telescope': telescope.id.split('.')[2],
+        'name': telescope.name,
+        'site': telescope.site,
+        'observatory': telescope.observatory
+      })
+    })
+    return telescopes;
+  }
+  return [];
+})
+
+const telescopeOptions = computed(() => {
+  const telescopes = telescopesByObservatory.value;
+  let telescopeItems = [];
+  for (const [observatory, sites] of Object.entries(telescopes)) {
+    telescopeItems.push({
+      props: {observatory: observatory}
+    });
+    for (const [site, telescopes] of Object.entries(sites)) {
+      telescopeItems.push({
+        props: {site: site}
+      });
+      telescopeItems.push(...telescopes);
+      telescopeItems.push({
+        props: { divider: true}
+      });
+    }
+  }
+  return telescopeItems;
+})
+
+
+function updateIndeterminateForObservatory(observatory) {
+  const telescopes = telescopesByObservatory.value;
+  let numSelected = 0;
+  let totalNum = 0;
+  if (telescopes[observatory]) {
+    for (const site of Object.values(telescopes[observatory])) {
+      for (const telescope of site) {
+        totalNum += 1;
+        if (filtersStore.queryParams.base.telescopes && filtersStore.queryParams.base.telescopes.includes(telescope.id)) {
+          numSelected += 1;
+        }
+      }
+    }
+    if (numSelected > 0 && totalNum != numSelected) {
+      indeterminateStates.value[observatory] = true;
+    }
+    else {
+      indeterminateStates.value[observatory] = false;
+    }
+  }
+  else {
+    indeterminateStates.value[observatory] = false;
+  }
+}
+
+
+function selectAllObservatory(selected, observatory) {
+  const telescopes = telescopesByObservatory.value;
+  if (telescopes[observatory]) {
+    if (filtersStore.queryParams.base.telescopes == null) {
+      filtersStore.queryParams.base.telescopes = [];
+    }
+    indeterminateStates.value[observatory] = false;
+    for (const site of Object.values(telescopes[observatory])) {
+      for (const telescope of site) {
+        let index = filtersStore.queryParams.base.telescopes.indexOf(telescope.id);
+        if (selected && index == -1) {
+          filtersStore.queryParams.base.telescopes.push(telescope.id);
+        }
+        else if (!selected && index > -1) {
+          filtersStore.queryParams.base.telescopes.splice(index, 1);
+        }
+      }
+    }
+    if (filtersStore.queryParams.base.telescopes.length == 0) {
+      filtersStore.queryParams.base.telescopes = null;
+    }
+  }
+}
+
+</script>
+
+<template>
+  <v-select
+    class="mt-6"
+    variant="outlined"
+    v-model="filtersStore.queryParams.base.telescopes"
+    :items="telescopeOptions"
+    item-value="id"
+    item-title="id"
+    label="Telescopes"
+    v-tooltip:top="'Optional filter on Telescopes'"
+    chips
+    closable-chips
+    multiple
+    clearable
+    >
+    <template #item="data">
+      <v-list-subheader v-if="data.props.observatory" class="pl-2 pt-10">
+        <v-row>
+          <v-col cols="5">
+            <b style="font-size:1.2rem;">{{ data.props.observatory }}</b>
+          </v-col>
+          <v-col cols="2" offset="2" style="align-content:center;">
+            <p class="pl-8">Select All: </p>
+          </v-col>
+          <v-col cols="1">
+            <v-checkbox-btn v-model="selectAllBtnStates[data.props.observatory]" class="pl-4" density="compact" :indeterminate="indeterminateStates[data.props.observatory]" @update:modelValue="selectAllObservatory($event, data.props.observatory)"></v-checkbox-btn>
+          </v-col>
+        </v-row>
+      </v-list-subheader>
+      <v-list-subheader v-else-if="data.props.site">
+        {{ data.props.site }}
+      </v-list-subheader>
+      <v-divider v-else-if="data.props.divider" />
+      <v-list-item v-else v-bind="data.props" class="pl-6" @click=updateIndeterminateForObservatory(data.item.raw.observatory)>
+        <v-list-item-subtitle>
+          {{ data.item.id }}
+        </v-list-item-subtitle>
+      </v-list-item>
+    </template>
+  </v-select>
+</template>
+<style scoped>
+
+.menu-chevron {
+  left: -6px;
+}
+
+</style>

--- a/src/stores/filters.js
+++ b/src/stores/filters.js
@@ -1,0 +1,148 @@
+import { defineStore } from "pinia";
+import { fetchApiCall } from '@/utils/api'
+
+export const useFiltersStore = defineStore("filters", {
+  state() {
+    return {
+      queryParams: {
+        base: {
+          start: null,
+          end: null,
+          telescopes: null,
+          max_airmass: 2.0,
+          min_lunar_distance: 0.0,
+          max_lunar_phase: 1.0,
+        },
+        siderealTarget: {
+          ra: null,
+          dec: null,
+          proper_motion_ra: null,
+          proper_motion_dec: null,
+          epoch: 2000.0,
+          parallax: null
+        },
+        nonSiderealTarget: {
+          epoch_of_elements: null,
+          epoch_of_perihelion: null,
+          orbital_inclination: null,
+          longitude_of_ascending_node: null,
+          longitude_of_perihelion: null,
+          argument_of_perihelion: null,
+          mean_distance: null,
+          perihelion_distance: null,
+          eccentricity: null,
+          mean_anomaly: null,
+          daily_motion: null
+        }
+      },
+      telescopes: null,
+      filteredTelescopes: [],
+      targetName: null,
+      targetType: 'SIDEREAL',
+      nonSiderealType: null,
+      visibilityAbort: null,
+      airmassAbort: null,
+      loadingVisibility: false,
+      loadingAirmass: false,
+      visibilityResults: null,
+      visibilityErrors: {},
+      airmassResults: null,
+      airmassErrors: {}
+    };
+  },
+  getters: {
+    getInstrument: (state) => (inst_id) => {
+      return state.getTelescopeForInstrument(inst_id).instruments.filter(inst => inst.id == inst_id)[0] || {};
+    },
+    getTelescopeForInstrument: (state) => (inst_id) => {
+      let telescope_id = inst_id.split('.').slice(0, 3).join('.');
+      return state.telescopes ? state.telescopes[telescope_id] || {} : {};
+    },
+    visilibityInput(state) {
+      let queryPayload = Object.fromEntries(Object.entries(state.queryParams.base).filter(([key, value]) => value == 0 || value))
+      if (state.targetType == 'SIDEREAL') {
+        queryPayload = Object.assign(
+          queryPayload,
+          Object.fromEntries(Object.entries(state.queryParams.siderealTarget).filter(([key, value]) => value == 0 || value))
+        )
+      }
+      else {
+        queryPayload = Object.assign(
+          queryPayload,
+          Object.fromEntries(Object.entries(state.queryParams.nonSiderealTarget).filter(([key, value]) => value == 0 || value))
+        )
+      }
+      return queryPayload;
+    }
+  },
+  actions: {
+    async queryVisibilityAndAirmass() {
+      if (this.loadingVisibility && this.visibilityAbort) {
+        this.visibilityAbort.signal.onabort = () => {
+          this.queryVisibility();
+        }
+        this.visibilityAbort.abort();
+      }
+      else {
+        this.queryVisibility();
+      }
+    },
+    async queryVisibility() {
+      this.visibilityAbort = new AbortController();
+      let queryPayload = this.visilibityInput;
+      this.loadingVisibility = true;
+      this.visibilityResults = null;
+      this.filteredTelescopes = Object.values(this.telescopes);
+      this.airmassResults = null;  // Also clear the airmass results since querying visibility then queries airmass after
+      this.visibilityErrors = {};
+      const url = import.meta.env.VITE_HEROIC_API_URL + 'visibility/intervals';
+      fetchApiCall({url: url, method: 'POST', body:queryPayload, signal:this.visibilityAbort.signal, successCallback: (data) => {
+        this.visibilityResults = data;
+        this.loadingVisibility = false;
+        this.visibilityAbort = null;
+        var telescopesWithVisibility = Object.keys(data).filter(key => data[key].length);
+        if (telescopesWithVisibility) {
+          if (this.telescopes){
+            this.filteredTelescopes = Object.values(this.telescopes).filter(obj => telescopesWithVisibility.includes(obj['id']))
+          }
+          this.queryAirmass(telescopesWithVisibility);
+        }
+      }, failCallback: (errors) => {
+        if (errors.name != 'AbortError'){
+          this.visibilityErrors = errors;
+          this.loadingVisibility = false;
+          this.visibilityAbort = null;
+        }
+        console.error('Failed to get target visibility intervals: ' + errors);
+      }})
+    },
+    async queryAirmass(telescopesOverride) {
+
+      if (this.loadingAirmass) {
+        this.airmassAbort.abort();
+      }
+      if (this.filteredTelescopes.length == 0) {
+        this.airmassErrors = {'Error': 'No telescopes have visibility. Please edit your parameters and try again.'};
+        this.loadingAirmass = false;
+      }
+      else {
+        this.airmassAbort = new AbortController();
+        let queryPayload = this.visilibityInput;
+        queryPayload.telescopes = telescopesOverride;
+        this.loadingAirmass = true;
+        this.airmassErrors = {};
+        const url = import.meta.env.VITE_HEROIC_API_URL + 'visibility/airmass';
+        fetchApiCall({url: url, method: 'POST', body:queryPayload, signal:this.airmassAbort.signal, successCallback: (data) => {
+          this.airmassResults = data;
+          this.loadingAirmass = false;
+          this.airmassAbort = null;
+        }, failCallback: (errors) => {
+          this.airmassErrors = errors;
+          console.error('Failed to get target airmass: ' + errors);
+          this.loadingAirmass = false;
+          this.airmassAbort = null;
+        }})
+      }
+    }
+  }
+});

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,6 +1,6 @@
 
 // handles api requests with the backend
-async function fetchApiCall({ url, method, body = null, header, successCallback = null, failCallback = handleError }) {
+async function fetchApiCall({ url, method, body = null, header, signal = null, successCallback = null, failCallback = handleError }) {
 
   const defaultHeader = {
     'Content-Type': 'application/json',
@@ -10,7 +10,8 @@ async function fetchApiCall({ url, method, body = null, header, successCallback 
   const config = {
     method: method,
     headers: header ? header : defaultHeader,
-    body: body ? JSON.stringify(body) : null
+    body: body ? JSON.stringify(body) : null,
+    signal: signal
   }
 
   try {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,96 +1,15 @@
 <script setup>
-import { ref, onMounted } from 'vue'
 import WorldMap from "../components/WorldMap.vue";
-import { fetchApiCall } from '@/utils/api'
+import { useFiltersStore } from '@/stores/filters'
 
-// const telescopes = [
-//   {
-//     "id": "lco.tst.doma-1m0a",
-//     "instruments": [
-//       {
-//         "id": "lco.tst.doma-1m0a.fa01",
-//         "name": "First Instrument 01",
-//         "available": true,
-//         "telescope": "lco.tst.doma-1m0a",
-//         "status": "SCHEDULABLE",
-//         "optical_element_groups": {
-//           "now": true
-//         },
-//         "operation_modes": {}
-//       }
-//     ],
-//     "name": "COJ 1m telescope 1",
-//     "aperture": 1.0,
-//     "latitude": -31.272932,
-//     "longitude": 149.070648,
-//     "horizon": 15.0,
-//     "positive_ha_limit": 4.6,
-//     "negative_ha_limit": -4.6,
-//     "zenith_blind_spot": 0.0,
-//     "site": "lco.tst",
-//     "status": "AVAILABLE"
-//   },
-//   {
-//     "id": "lco.tst.doma-1m0b",
-//     "instruments": [
-//       {
-//         "id": "lco.tst.doma-1m0b.fa02",
-//         "name": "First Instrument 02",
-//         "available": true,
-//         "telescope": "lco.tst.doma-1m0b",
-//         "status": "SCHEDULABLE",
-//         "optical_element_groups": {
-//           "now": true
-//         },
-//         "operation_modes": {}
-//       }
-//     ],
-//     "name": "COJ 1m telescope 2",
-//     "aperture": 1.0,
-//     "latitude": -31.272931,
-//     "longitude": 149.070647,
-//     "horizon": 15.0,
-//     "positive_ha_limit": 4.6,
-//     "negative_ha_limit": -4.6,
-//     "zenith_blind_spot": 0.0,
-//     "site": "lco.tst",
-//     "status": "UNAVAILABLE"
-//   },
-//   {
-//     "id": "lco.tst2.doma-1m0a",
-//     "instruments": [],
-//     "name": "LSC  1m 1",
-//     "aperture": 1.0,
-//     "latitude": -30.1674472222,
-//     "longitude": -70.8046805556,
-//     "horizon": 15.0,
-//     "positive_ha_limit": 4.6,
-//     "negative_ha_limit": -4.6,
-//     "zenith_blind_spot": 0.0,
-//     "site": "lco.tst2"
-//   }
-// ]
-
-const telescopes = ref([])
-
-async function getTelescopes() {
-  const url = import.meta.env.VITE_HEROIC_API_URL + 'telescopes' + '/?limit=1000';
-  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
-    telescopes.value = data.results;
-  }})
-}
-
-
-onMounted(async () => {
-  getTelescopes();
-})
+const filtersStore = useFiltersStore()
 
 </script>
 
 <template>
   <v-container fluid>
     <world-map
-      :telescopes="telescopes"
+      :telescopes="filtersStore.filteredTelescopes"
     ></world-map>
   </v-container>
 </template>

--- a/src/views/InstrumentsView.vue
+++ b/src/views/InstrumentsView.vue
@@ -1,24 +1,79 @@
 <script setup>
-import { ref } from 'vue'
-import DataTable from "../components/DataTable.vue";
+import { ref, computed } from 'vue'
+import { useFiltersStore } from '@/stores/filters'
+
+const filtersStore = useFiltersStore()
+const searchText = ref('');
 
 const instrumentHeaders = ref([
-  {title: 'Name', align: 'start', sortable: true, key: 'name'},
+  {title: 'Name', align: 'start', sortable: true, key: 'name', value: 'name'},
   {title: 'Status', align: 'end', sortable: true, key: 'status'},
   {title: 'Telescope', align: 'end', sortable: true, key: 'telescope'},
   {title: 'Optical Elements', align: 'end', sortable: true, key: 'optical_element_groups'},
   {title: 'Modes', align: 'end', sortable: true, key: 'operation_modes'}
 ])
 
+const filteredInstruments = computed(() => {
+  if (baseFilteredInstruments.value && searchText.value) {
+    const searchTerm = searchText.value.toLowerCase();
+    return baseFilteredInstruments.value.filter(item => item['name'].toLowerCase().includes(searchTerm) || item['id'].toLowerCase().includes(searchTerm))
+  }
+  return baseFilteredInstruments.value;
+})
+
+const baseFilteredInstruments = computed(() => {
+  var instruments = [];
+  filtersStore.filteredTelescopes.forEach(telescope => {
+    instruments.push(...telescope.instruments);
+  })
+  return instruments;
+})
+
+const totalInstrumentCount = computed(() => {
+  var instrumentTotal = 0;
+  if (filtersStore.telescopes){
+    Object.values(filtersStore.telescopes).forEach(telescope => {
+      instrumentTotal += telescope.instruments.length;
+    })
+  }
+  return instrumentTotal;
+})
+
+function generateItemLink(item) {
+  var detailPage = 'instrumentDetail';
+  return { name: detailPage, params: { id: item.id } };
+}
+
 </script>
 
 <template>
   <v-container fluid>
-    <h1>Instrument Data:</h1>
-    <data-table
-      apiKey="instruments"
-      :headers=instrumentHeaders
-    ></data-table>
+    <v-row class="pb-1">
+      <v-col cols="5">
+        <h1>Filtered Instrument Data:</h1>
+      </v-col>
+      <v-col offset="1" cols="4">
+        <v-text-field v-model="searchText" prepend-inner-icon="mdi-magnify" label="search" variant="outlined" hide-details single-line clearable></v-text-field>
+      </v-col>
+      <v-col cols="2" align="right" style="align-content: center;">
+        <p>Showing: {{ filteredInstruments.length }} / {{ totalInstrumentCount }}</p>
+      </v-col>
+    </v-row>
+    <v-data-table-virtual
+      :headers="instrumentHeaders"
+      :items="filteredInstruments"
+      item-key="id"
+    >
+      <template #item.name="{ item }">
+        <router-link :to="generateItemLink(item)">{{ item.name }}</router-link>
+      </template>
+      <template #item.optical_element_groups="{ item }">
+        {{ Object.keys(item.optical_element_groups).join(', ') }}
+      </template>
+      <template #item.operation_modes="{ item }">
+        {{ Object.keys(item.operation_modes).join(', ') }}
+      </template>
+    </v-data-table-virtual>
   </v-container>
 </template>
 <style>

--- a/src/views/TelescopeDetailsView.vue
+++ b/src/views/TelescopeDetailsView.vue
@@ -1,39 +1,134 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router';
-import { fetchApiCall } from '@/utils/api'
+import { useFiltersStore } from '@/stores/filters'
+import TelescopeStatusTimeline from '@/components/TelescopeStatusTimeline.vue'
+
+const filtersStore = useFiltersStore()
 
 const route = useRoute();
-const telescopeData = ref({})
 
-async function loadTelescope(telescopeId) {
-  const url = import.meta.env.VITE_HEROIC_API_URL + 'telescopes/' + telescopeId + '/';
-  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
-    telescopeData.value = data;
-  }})
+const telescopeData = computed(() => {
+  if (filtersStore.telescopes) {
+    return filtersStore.telescopes[route.params.id] || {};
+  }
+  return {};
+})
+
+const observatorySiteLabel = computed(() => {
+  return telescopeData.value ? telescopeData.value.observatory_name + ' > ' + telescopeData.value.site_name : '';
+})
+
+const currentTwilight = computed(() => {
+  if (telescopeData.value && telescopeData.value.next_twilight && telescopeData.value.next_twilight.length > 1) {
+    return telescopeData.value.next_twilight[0];
+  }
+  return null;
+})
+
+const nextTwilight = computed(() => {
+  if (telescopeData.value && telescopeData.value.next_twilight) {
+    if (telescopeData.value.next_twilight.length > 1) {
+      return telescopeData.value.next_twilight[1];
+    }
+    return telescopeData.value.next_twilight[0];
+  }
+  return null;
+})
+
+function generateItemLink(item) {
+  var detailPage = 'instrumentDetail';
+  return { name: detailPage, params: { id: item.id } };
 }
-
-const formattedTelescopeData = computed(() => {
-  return JSON.stringify(telescopeData.value, null, 4);
-})
-
-onMounted(async () => {
-  loadTelescope(route.params.id);
-})
 
 </script>
 
 <template>
   <v-container fluid>
-    <h1>Telescope {{ route.params.id }} Data:</h1>
-    <v-textarea
-      :model-value="formattedTelescopeData"
-      auto-grow
-      readonly
-      >
-    </v-textarea>
+    <h4 class="label-text ml-2" style="margin-bottom:-6px;">
+      {{ observatorySiteLabel }}
+      <v-btn v-if="telescopeData.weather_url" color="blue-darken-2" icon="mdi-weather-cloudy-arrow-right" variant="text" v-tooltip="telescopeData.weather_url" :href="telescopeData.weather_url" target="_blank"></v-btn>
+    </h4>
+    <h1>
+      {{ telescopeData.name }}
+      <v-btn v-if="telescopeData.telescope_url" color="blue-darken-2" icon="mdi-open-in-new" variant="text" v-tooltip="telescopeData.telescope_url" :href="telescopeData.telescope_url" target="_blank"></v-btn>
+    </h1>
+    <v-divider thickness="3"></v-divider>
+    <v-row>
+      <v-col cols="9" class="large-text">
+        <v-row class="mt-2 ml-2">
+          <p class="label-text">Latitude: </p>
+          <b class="ml-2">{{ telescopeData.latitude }}</b>
+        </v-row>
+        <v-row class="mt-2 ml-2">
+          <p class="label-text">Longitude: </p>
+          <b class="ml-2">{{ telescopeData.longitude }}</b>
+        </v-row>
+        <v-row class="mt-2 ml-2">
+          <p class="label-text">Aperture: </p>
+          <b class="ml-2">{{ telescopeData.aperture }} meters</b>
+        </v-row>
+        <v-row class="mt-2 ml-2">
+          <p class="label-text">Current Status: </p>
+          <b class="ml-2">{{ telescopeData.status }}</b>
+        </v-row>
+        <v-row class="mt-2 ml-2" v-if="currentTwilight">
+          <p class="label-text">Current Twilight: </p>
+          <b class="ml-2">Now to {{ new Date(currentTwilight[1]).toGMTString() }}</b>
+        </v-row>
+        <v-row class="mt-2 ml-2" v-if="nextTwilight">
+          <p class="label-text">Next Twilight: </p>
+          <b class="ml-2">{{ new Date(nextTwilight[0]).toGMTString() }} to {{ new Date(nextTwilight[1]).toGMTString() }}</b>
+        </v-row>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12">
+        <v-row class="mt-2 ml-2">
+          <v-table style="width:1150px;">
+            <thead>
+              <tr>
+                <th class="text-left">Instruments</th>
+                <th class="text-left border-left">Status</th>
+                <th class="text-left border-left">Optical Element Types</th>
+                <th class="text-left border-left">Operation Modes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="inst in telescopeData.instruments"
+                :key="inst.id"
+              >
+                <td><router-link :to="generateItemLink(inst)">{{ inst.name }}</router-link></td>
+                <td class="border-left">{{ inst.status }}</td>
+                <td class="border-left">{{ Object.keys(inst.optical_element_groups).join(', ') }}</td>
+                <td class="border-left">{{ Object.keys(inst.operation_modes).join(', ') }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-row>
+      </v-col>
+    </v-row>
+    <v-row>
+      <telescope-status-timeline
+        :telescope="route.params.id"
+        class="pt-4 pl-4"
+      ></telescope-status-timeline>
+    </v-row>
   </v-container>
 </template>
-<style>
+<style scoped>
+.border-left {
+  border-left: 1px solid dimgray;
+}
+
+.large-text {
+  font-size: 1.4rem;
+  color: lightgray;
+}
+
+.label-text {
+  color: darkgray;
+}
 
 </style>

--- a/src/views/TelescopesView.vue
+++ b/src/views/TelescopesView.vue
@@ -1,25 +1,56 @@
 <script setup>
-import { ref } from 'vue'
-import DataTable from "../components/DataTable.vue";
+import { ref, computed } from 'vue'
+import { useFiltersStore } from '@/stores/filters'
+
+const filtersStore = useFiltersStore()
+const searchText = ref('');
 
 const telescopeHeaders = ref([
-  {title: 'Name', align: 'start', sortable: true, key: 'name'},
-  {title: 'Site', align: 'start', sortable: true, key: 'site'},
+  {title: 'Name', align: 'start', sortable: true, key: 'name', value: 'name'},
+  {title: 'Site', align: 'start', sortable: true, key: 'site', value: 'site'},
   {title: 'Aperture (m)', align: 'end', sortable: true, key: 'aperture'},
   {title: 'Status', align: 'end', sortable: true, key: 'status'},
   {title: 'Latitude', align: 'end', sortable: true, key: 'latitude'},
   {title: 'Longitude', align: 'end', sortable: true, key: 'longitude'}
 ])
 
+function generateItemLink(item) {
+  var detailPage = 'telescopeDetail';
+  return { name: detailPage, params: { id: item.id } };
+}
+
+const filteredTelescopes = computed(() => {
+  if (filtersStore.filteredTelescopes && searchText.value) {
+    const searchTerm = searchText.value.toLowerCase();
+    return filtersStore.filteredTelescopes.filter(item => item['name'].toLowerCase().includes(searchTerm) || item['id'].toLowerCase().includes(searchTerm))
+  }
+  return filtersStore.filteredTelescopes;
+})
+
 </script>
 
 <template>
   <v-container fluid>
-    <h1>Telescope Data:</h1>
-    <data-table
-      apiKey="telescopes"
-      :headers=telescopeHeaders
-    ></data-table>
+    <v-row class="pb-1">
+      <v-col cols="4">
+        <h1>Filtered Telescope Data:</h1>
+      </v-col>
+      <v-col offset="2" cols="4">
+        <v-text-field v-model="searchText" prepend-inner-icon="mdi-magnify" label="search" variant="outlined" hide-details single-line clearable></v-text-field>
+      </v-col>
+      <v-col cols="2" align="right" style="align-content: center;">
+        <p>Showing: {{ filteredTelescopes.length }} / {{ filtersStore.telescopes ? Object.keys(filtersStore.telescopes).length: 0 }}</p>
+      </v-col>
+    </v-row>
+    <v-data-table-virtual
+      :headers="telescopeHeaders"
+      :items="filteredTelescopes"
+      item-key="id"
+    >
+      <template #item.name="{ item }">
+        <router-link :to="generateItemLink(item)">{{ item.name }}</router-link>
+      </template>
+    </v-data-table-virtual>
   </v-container>
 </template>
 <style>

--- a/src/views/VisibilityView.vue
+++ b/src/views/VisibilityView.vue
@@ -1,7 +1,6 @@
 <script setup>
-import { onMounted, ref, provide } from 'vue'
-import DatePicker from '@vuepic/vue-datepicker';
-import { fetchApiCall } from '@/utils/api'
+import { ref, provide, watch } from 'vue'
+import { useFiltersStore } from '@/stores/filters'
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { LineChart } from 'echarts/charts';
@@ -29,61 +28,44 @@ use([
 provide(THEME_KEY, 'dark');
 
 const airmassPlot = ref(null);
-const telescopeOptions = ref();
-const targetType = ref('SIDEREAL');
-const nonSiderealType = ref('MPC_MINOR_PLANET')
-const searchTarget = ref();
-const searchTargetErrors = ref();
-const searchTargetSuccess = ref();
-const loadingQuery = ref(false);
-const queryErrors = ref({});
+const seriesIndexToTelescope = ref([]);
+const filtersStore = useFiltersStore()
 
-// The payload for the visibility query API
-const payload = ref({
-  start: new Date(),
-  end: new Date(Date.now() + (3600 * 1000 * 24)),
-  telescopes: null,
-  max_airmass: 2.0,
-  min_lunar_distance: 0.0,
-  max_lunar_phase: 1.0,
-});
-
-const siderealTargetPayload = ref({
-  ra: null,
-  dec: null,
-  proper_motion_ra: null,
-  proper_motion_dec: null,
-  epoch: 2000.0,
-  parallax: null
-})
-
-const nonsiderealTargetPayload = ref({
-  epoch_of_elements: null,
-  epoch_of_perihelion: null,
-  orbital_inclination: null,
-  longitude_of_ascending_node: null,
-  longitude_of_perihelion: null,
-  argument_of_perihelion: null,
-  mean_distance: null,
-  perihelion_distance: null,
-  eccentricity: null,
-  mean_anomaly: null,
-  daily_motion: null
-})
 
 const airmassChartUpdateOptions = ref({
   replaceMerge: ['series', 'legend']
 })
+
+var tooltipCallback = (seriesArray) => {
+  var date = null;
+  var bulk =  '';
+  seriesArray.forEach(series => {
+    bulk += '<div style="margin: 10px 0 0;line-height:1;"><div class="ec-tooltip-base" style="float:left;">';
+    bulk += series.marker;
+    bulk += '</div>';
+    bulk += '<span class="ec-tooltip-text" style="margin-left:2px;float:left;">' + seriesIndexToTelescope.value[series.seriesIndex] + '</span>';
+    bulk += '<span class="ec-tooltip-value">' + series.data[1] + '</span></div>';
+    bulk += '<div style="clear:both;">';
+    bulk += '</div>'
+    date = series.axisValueLabel;
+  })
+  let tooltip = '<div class="ec-tooltip-base">';
+  tooltip += '<div class="ec-tooltip-text" style="line-height:1;">' + date + '</div>';
+  tooltip += bulk;
+  tooltip += '</div><div style="clear:both;"></div>';
+  return tooltip;
+}
 
 const airmassChartOptions = ref({
   title: {
     text: '',
   },
   tooltip: {
-    trigger: 'axis'
+    trigger: 'axis',
+    formatter: tooltipCallback
   },
   legend: {
-    data: []
+    data: [],
   },
   grid: {
     left: '3%',
@@ -127,37 +109,14 @@ const airmassChartOptions = ref({
 });
 
 
-onMounted(async () => {
-  // Fetch the telescope options from the API to populate the telescope select field
-  const url = import.meta.env.VITE_HEROIC_API_URL + 'telescopes' + '/?limit=1000';
-  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
-    telescopeOptions.value = data.results;
-  }})
-})
-
-async function queryVisibility() {
-  // hit the HEROIC airmass API and generate a plot from results
-  loadingQuery.value = true;
-  queryErrors.value = {};
-  let queryPayload = Object.fromEntries(Object.entries(payload.value).filter(([key, value]) => value == 0 || value))
-  if (targetType.value == 'SIDEREAL') {
-    queryPayload = Object.assign(
-      queryPayload,
-      Object.fromEntries(Object.entries(siderealTargetPayload.value).filter(([key, value]) => value == 0 || value))
-    )
-  }
-  else {
-    queryPayload = Object.assign(
-      queryPayload,
-      Object.fromEntries(Object.entries(nonsiderealTargetPayload.value).filter(([key, value]) => value == 0 || value))
-    )
-  }
-  const url = import.meta.env.VITE_HEROIC_API_URL + 'visibility/airmass';
-  await fetchApiCall({url: url, method: 'POST', body:queryPayload, successCallback: (data) => {
-    console.log(data);
-    airmassChartOptions.value.series = []
-    airmassChartOptions.value.legend.data = []
+watch(() => filtersStore.$state.airmassResults, () => {
+  const data = filtersStore.$state.airmassResults
+  if (data) {
+    seriesIndexToTelescope.value = [];
+    airmassChartOptions.value.series = [];
+    airmassChartOptions.value.legend.data = [];
     for (const telescope in data) {
+      let condensedName = telescope.split('.').slice(0, 2).join('.');
       let previousTime = new Date(data[telescope].times[0]);
       let dataArray = [];
       for (let i = 0; i < data[telescope].times.length; i++) {
@@ -165,10 +124,11 @@ async function queryVisibility() {
         // If the times are more than 20 minutes apart, start a new series since its no longer continuous
         if (((currentTime - previousTime) / 1000.0 / 60.0) > 20) {
           airmassChartOptions.value.series.push({
-            name: telescope,
+            name: condensedName,
             type: 'line',
             data: [...dataArray]
           })
+          seriesIndexToTelescope.value.push(telescope);
           dataArray = []
         }
         dataArray.push([data[telescope].times[i], data[telescope].airmasses[i]])
@@ -176,434 +136,69 @@ async function queryVisibility() {
       }
       if (dataArray) {
         airmassChartOptions.value.series.push({
-          name: telescope,
+          name: condensedName,
           type: 'line',
           data: [...dataArray]
         })
+        seriesIndexToTelescope.value.push(telescope);
       }
-      airmassChartOptions.value.legend.data.push(telescope)
+      airmassChartOptions.value.legend.data.push(condensedName)
     }
-    loadingQuery.value = false;
-  }, failCallback: (errors) => {
+  }
+}, {immediate: true})
+
+watch(() => filtersStore.$state.airmassErrors, () => {
+  if (Object.keys(filtersStore.$state.airmassErrors).length > 0){
     airmassChartOptions.value.series = []
     airmassChartOptions.value.legend.data = []
-    queryErrors.value = errors;
-    console.error('Failed to get target airmass: ' + errors);
-    loadingQuery.value = false;
-  }})
-}
-
-async function callSearchTarget () {
-  // search for target parameters from simbad2k service and prefill the fields if found
-  searchTargetErrors.value = null;
-  let url = import.meta.env.VITE_SIMBAD2K_API_URL + searchTarget.value + '?target_type=' + targetType.value;
-  if (targetType.value == 'NON_SIDEREAL') {
-    url = url + '&scheme=' + nonSiderealType.value;
   }
-  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
-    console.log(data)
-    fillInTarget(data);
-    if (data.error) {
-      // In this case, the API has not found a result, so inform the user of that
-      searchTargetErrors.value = data.error;
-    }
-    else {
-      searchTargetSuccess.value = 'Found target:' + data.name;
-    }
-  }, failCallback: (response) => {
-    let error = response.error || response;
-    searchTargetErrors.value = error;
-    console.error('Failed to get target details for ' + searchTarget.value + ' from simbad2k: ' + error);
-  }})
-}
-
-function fillInTarget(targetData) {
-  siderealTargetPayload.value.ra = targetData.ra_d || targetData.ra || null
-  siderealTargetPayload.value.dec = targetData.dec_c || targetData.dec || null
-  siderealTargetPayload.value.proper_motion_ra = targetData.pmra || null
-  siderealTargetPayload.value.proper_motion_dec = targetData.pmdec || null
-  siderealTargetPayload.value.parallax = targetData.plx_value || null
-  nonsiderealTargetPayload.value.epoch_of_elements = targetData.epoch_jd ? targetData.epoch_jd - 2400000.5 : null;
-  nonsiderealTargetPayload.value.longitude_of_ascending_node = targetData.ascending_node || null;
-  nonsiderealTargetPayload.value.orbital_inclination = targetData.inclination || null;
-  nonsiderealTargetPayload.value.argument_of_perihelion = targetData.argument_of_perihelion || null;
-  nonsiderealTargetPayload.value.eccentricity = targetData.eccentricity || null;
-  nonsiderealTargetPayload.value.mean_distance = targetData.semimajor_axis || null;
-  nonsiderealTargetPayload.value.mean_anomaly = targetData.mean_anomaly || null;
-  nonsiderealTargetPayload.value.daily_motion = targetData.mean_daily_motion || null;
-  nonsiderealTargetPayload.value.perihelion_distance = targetData.perihelion_distance || null;
-  nonsiderealTargetPayload.value.epoch_of_perihelion = targetData.perihelion_date_jd ? targetData.perihelion_date_jd - 2400000.5 : null;
-}
-
-function clearTargetErrors() {
-  searchTargetErrors.value = null;
-  searchTargetSuccess.value = undefined;
-}
-
-function onChangeTargetType() {
-  // Reset the target fields to null and remove any target from the search bar when switching target types
-  searchTarget.value = null;
-  clearTargetErrors();
-  fillInTarget({});
-}
+})
 
 </script>
 
 <template>
   <v-container fluid>
     <v-row>
-      <v-col cols="5">
-        <v-row>
-          <v-col cols="7">
-            <h2>Target Visibility Query</h2>
-          </v-col>
-          <v-col cols="5">
-            <v-btn
-              :loading="loadingQuery"
-              variant="tonal"
-              @click="queryVisibility"
-              >Plot Visibility
-            </v-btn>
-          </v-col>
-        </v-row>
-        <v-divider class="mt-2" thickness="2"></v-divider>
-        <v-alert v-if="queryErrors.non_field_errors" type="error" :text="queryErrors.non_field_errors.join(', ')" closable></v-alert>
-        <v-form>
-          <v-row>
-            <v-col cols="5">
-              <div class="datepicker-group mt-6">
-                <v-label v-if="payload.start" id="start-dp-label" class="datepicker-label">Start Date</v-label> 
-                <DatePicker v-model="payload.start" id="start-dt-picker" model-type="iso" placeholder="Start Date" label="Start" required dark></DatePicker>
-              </div>
-              <div class="datepicker-group mt-6">
-                <v-label v-if="payload.end" id="end-dp-label" class="datepicker-label">End Date</v-label> 
-                <DatePicker v-model="payload.end" model-type="iso" placeholder="End Date" required dark></DatePicker>
-              </div>
-              <v-select
-                class="mt-6"
-                variant="outlined"
-                v-model="payload.telescopes"
-                :items="telescopeOptions"
-                item-value="id"
-                item-title="id"
-                label="Telescopes"
-                v-tooltip:top="'Optional filter on Telescopes'"
-                chips
-                multiple>
-              </v-select>
-              <v-number-input
-                label="Max Airmass"
-                control-variant="stacked"
-                v-model="payload.max_airmass"
-                :min="1"
-                :max="10"
-                :step="0.1"
-                :precision="1"
-              >
-              </v-number-input>
-              <v-number-input
-                label="Max Lunar Phase"
-                control-variant="stacked"
-                v-model="payload.max_lunar_phase"
-                :min="0"
-                :max="1"
-                :step="0.1"
-                :precision="1"
-              >
-              </v-number-input>
-              <v-number-input
-                label="Min Lunar Distance"
-                control-variant="stacked"
-                v-model="payload.min_lunar_distance"
-                :min="0"
-                :max="180"
-                :step="1"
-              >
-              </v-number-input>
-            </v-col>
-            <v-col cols="6" offset="1">
-              <v-btn-toggle class="mt-4" v-model="targetType" color="deep-purple-accent-4" density="compact" group @update:modelValue="onChangeTargetType">
-                <v-btn value="SIDEREAL">Sidereal</v-btn>
-                <v-btn value="NON_SIDEREAL">Non-Sidereal</v-btn>
-              </v-btn-toggle>
-              <v-btn-toggle class="mt-4 button-stack" v-if="targetType=='NON_SIDEREAL'" v-model="nonSiderealType" color="deep-purple-accent-4" group>
-                <v-btn value="MPC_MINOR_PLANET" size="large">MPC Minor Planet</v-btn>
-                <v-btn value="MPC_COMET" size="large">MPC Comet</v-btn>
-                <v-btn value="JPL_MAJOR_PLANET" size="large">JPL Major Planet</v-btn>
-              </v-btn-toggle>
-              <v-text-field
-                class="mt-4"
-                variant="outlined"
-                label="Prefill Target"
-                v-model="searchTarget"
-                :error-messages="searchTargetErrors"
-                :base-color="searchTargetSuccess ? 'success': undefined"
-                :color="searchTargetSuccess ? 'success': undefined"
-                :messages="searchTargetSuccess"
-                @input="clearTargetErrors"
-              >
-                <template v-slot:append-inner>
-                  <v-btn :disabled="!searchTarget" @click="callSearchTarget">Search</v-btn>
-                </template>
-              </v-text-field>
-              <div v-if="targetType=='SIDEREAL'" class="mt-4">
-                <v-number-input
-                  label="Right Ascension (decimal degrees)"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="siderealTargetPayload.ra"
-                  :min="0"
-                  :max="360"
-                  :precision="9"
-                  :error-messages="queryErrors.ra"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Declination (decimal degrees)"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="siderealTargetPayload.dec"
-                  :min="-90"
-                  :max="90"
-                  :precision="9"
-                  :error-messages="queryErrors.dec"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Proper Motion RA (mas/yr)"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="siderealTargetPayload.proper_motion_ra"
-                  :min="-20000"
-                  :max="20000"
-                  :precision="9"
-                  :error-messages="queryErrors.proper_motion_ra"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Proper Motion Dec (mas/yr)"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="siderealTargetPayload.proper_motion_dec"
-                  :min="-20000"
-                  :max="20000"
-                  :precision="9"
-                  :error-messages="queryErrors.proper_motion_dec"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Epoch"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="siderealTargetPayload.epoch"
-                  :min="1900"
-                  :max="2100"
-                  :precision="2"
-                  :error-messages="queryErrors.epoch"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Parallax (mas)"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="siderealTargetPayload.parallax"
-                  :min="-2000"
-                  :max="2000"
-                  :precision="2"
-                  :error-messages="queryErrors.parallax"
-                >
-                </v-number-input>
-              </div>
-              <div v-if="targetType=='NON_SIDEREAL'" class="mt-4">
-                <v-number-input
-                  class="mt-2"
-                  label="Epoch of Elements"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.epoch_of_elements"
-                  :min="10000"
-                  :max="100000"
-                  :precision="1"
-                  :error-messages="queryErrors.epoch_of_elements"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Orbital Inclination"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.orbital_inclination"
-                  :min="0"
-                  :max="180"
-                  :precision="17"
-                  :error-messages="queryErrors.orbital_inclination"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Longitude of Ascending Node"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.longitude_of_ascending_node"
-                  :min="0"
-                  :max="360"
-                  :precision="17"
-                  :error-messages="queryErrors.longitude_of_ascending_node"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Argument of Perihelion"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.argument_of_perihelion"
-                  :min="0"
-                  :max="360"
-                  :precision="17"
-                  :error-messages="queryErrors.argument_of_perihelion"
-                >
-                </v-number-input>
-                <v-number-input
-                  class="mt-2"
-                  label="Eccentricity"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.eccentricity"
-                  :min="0"
-                  :precision="17"
-                  :error-messages="queryErrors.eccentricity"
-                >
-                </v-number-input>
-                <v-number-input
-                  v-if="nonSiderealType!='MPC_COMET'"
-                  class="mt-2"
-                  label="Mean Distance"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.mean_distance"
-                  :min="0"
-                  :precision="17"
-                  :error-messages="queryErrors.mean_distance"
-                >
-                </v-number-input>
-                <v-number-input
-                  v-if="nonSiderealType=='MPC_COMET'"
-                  class="mt-2"
-                  label="Perihelion Distance"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.perihelion_distance"
-                  :min="0"
-                  :precision="17"
-                  :error-messages="queryErrors.perihelion_distance"
-                >
-                </v-number-input>
-                <v-number-input
-                  v-if="nonSiderealType!='MPC_COMET'"
-                  class="mt-2"
-                  label="Mean Anomaly"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.mean_anomaly"
-                  :min="0"
-                  :max="360"
-                  :precision="17"
-                  :error-messages="queryErrors.mean_anomaly"
-                >
-                </v-number-input>
-                <v-number-input
-                  v-if="nonSiderealType=='MPC_COMET'"
-                  class="mt-2"
-                  label="Epoch of Perihelion"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.epoch_of_perihelion"
-                  :min="361"
-                  :max="240000"
-                  :precision="7"
-                  :error-messages="queryErrors.epoch_of_perihelion"
-                >
-                </v-number-input>
-                <v-number-input
-                  v-if="nonSiderealType=='JPL_MAJOR_PLANET'"
-                  class="mt-2"
-                  label="Daily Motion"
-                  variant="outlined"
-                  density="compact"
-                  control-variant="hidden"
-                  v-model="nonsiderealTargetPayload.daily_motion"
-                  :min="0"
-                  :precision="17"
-                  :error-messages="queryErrors.daily_motion"
-                >
-                </v-number-input>
-              </div>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col cols="12" :align="'center'">
-              <v-btn
-                :loading="loadingQuery"
-                size="x-large"
-                variant="tonal"
-                @click="queryVisibility"
-                >Plot Visibility
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-form>
-      </v-col>
-      <v-col cols="6" align="center">
+      <v-col align="center" v-if="filtersStore.airmassResults">
         <h2>Airmass Plot</h2>
         <v-chart class="chart" :option="airmassChartOptions" :update-options="airmassChartUpdateOptions" autoresize/>
+      </v-col>
+      <v-col align="center" v-else-if="filtersStore.loadingAirmass || filtersStore.loadingVisibility">
+        <h1 class="mt-10">
+          Loading visibility data
+          <v-progress-linear indeterminate></v-progress-linear>
+        </h1>
+      </v-col>
+      <v-col align="center" v-else>
+        <h1 class="mt-10">You must fill in Target details and a date range to generate visibility</h1>
       </v-col>
     </v-row>
   </v-container>
 </template>
 <style>
 
+.ec-tooltip-base {
+  margin: 0px 0 0;
+  line-height: 1;
+}
+
+.ec-tooltip-text {
+  font-size: 14px;
+  color: #666;
+  font-weight: 400;
+}
+
+.ec-tooltip-value {
+  float: right;
+  margin-left: 20px;
+  font-size: 14px;
+  color: #666;
+  font-weight: 900;
+}
+
 .chart {
   max-height: 500px;
+  min-height: 500px;
 }
-
-.datepicker-group {
-  position: relative;
-}
-
-.button-stack {
-  flex-direction: column;
-  padding-left:12px;
-  height: auto !important;
-}
-
-.datepicker-label {
-  z-index: 2;
-  position:absolute;
-  font-size:small;
-  top:-12px;
-  left: 8px;
-  background-color: var(--vt-c-black);
-}
-
 
 </style>


### PR DESCRIPTION
… each page, and fleshed out the details pages

There are many many changes here, but the easiest way to describe them is to show them in this video. Basically now the target/date/constraints are global and persistent across all pages of the app - so setting them once preloads the visibility/airmass and applies that to all pages you visit after. Also the telescope/instrument detail pages have a bit more content in them then before.

[heroic_ui_2.webm](https://github.com/user-attachments/assets/cf0ab358-6113-486e-bda3-0b929925876b)
