### PR TITLE
Integrate planned future statuses into frontend and fix a number of f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+[Dd]ist/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="">
   <head>
     <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" href="https://scimma.org/static/imgs/logos/logo_transparent.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <title>HEROIC</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@ onMounted(async () => {
         site.telescopes.forEach(telescope => {
           telescopes[telescope.id] = telescope;
           telescopes[telescope.id]['observatory_name'] = observatory.name;
+          telescopes[telescope.id]['observatory'] = observatory.id;
           telescopes[telescope.id]['site_name'] = site.name;
           telescopes[telescope.id]['weather_url'] = site.weather_url;
           telescopes[telescope.id]['elevation'] = site.elevation;

--- a/src/assets/timeline.css
+++ b/src/assets/timeline.css
@@ -1,0 +1,62 @@
+.vis-time-axis .vis-text {
+  color: #b3b3b3 !important;
+}
+
+.vis-labelset .vis-label {
+  color: #b3b3b3 !important;
+}
+
+.vis-item.VISIBLE {
+  background-color: rgb(185, 115, 234);
+  border-color: rgb(167, 71, 234);
+}
+
+.vis-item.AVAILABLE {
+  background-color: cyan;
+  border-color: cyan;
+}
+
+.vis-item.UNAVAILABLE {
+  background-color: coral;
+  border-color: coral;
+}
+
+.vis-item.SCHEDULABLE {
+  background-color: lightgreen;
+  border-color: lightgreen;
+}
+
+.vis-item.sun-up {
+  background-color: lightyellow !important;
+}
+
+.info-button {
+  left:-10px;
+  top: -10px;
+}
+
+.add-button {
+  position: relative;
+  bottom: 50px;
+  left: 12px;
+}
+
+.datepicker-label {
+  z-index: 2;
+  position:relative;
+  font-size:small;
+  top: 10px;
+  left: 8px;
+  background-color: var(--vt-c-black);
+}
+
+.vis-delete {
+  display: flex;
+  align-items: center;
+  border-radius: 25px;
+  right: -26px;
+}
+
+.vis-timeline {
+  overflow:visible !important;
+}

--- a/src/components/PlannedTimeline.vue
+++ b/src/components/PlannedTimeline.vue
@@ -1,0 +1,355 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import DatePicker from '@vuepic/vue-datepicker';
+import { fetchApiCall, capitalize } from '@/utils/api'
+import { useUserStore } from '@/stores/user';
+import TelescopeSelect from '@/components/global/TelescopeSelect.vue'
+import InstrumentSelect from '@/components/global/InstrumentSelect.vue';
+import StatusTimelineLegend from '@/components/global/StatusTimelineLegend.vue';
+import { DataSet, Timeline } from 'vis-timeline/standalone';
+import 'vis-timeline/styles/vis-timeline-graph2d.css';
+import "@/assets/timeline.css"
+
+const props = defineProps({
+  apiEndpoint: {
+    type: String,
+    required: true
+  },
+  type: {
+    type: String,
+    required: true
+  },
+  parentKey: {
+    type: String,
+    required: true
+  },
+  start: {
+    type: String,
+    default: () => (new Date()).toISOString()
+  },
+  end: {
+    type: String,
+    required: false
+  },
+  telescopes: {
+    type: Array,
+    required: false
+  },
+  editable: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const userStore = useUserStore()
+
+const timelineDiv = ref(null);
+
+const apiItems = ref([]);
+const keySet = new Set();
+
+const deleteDialog = ref(false);
+const deleteDialogCallback = ref(null);
+const deleteDialogItem = ref(null);
+
+const addDialog = ref(false);
+const addDialogCallback = ref(null);
+const addDialogItem = ref(null);
+
+var last_end = new Date();
+var timeline = null;
+const visItems = new DataSet();
+const visGroups = new DataSet();
+
+
+const helpText = computed(() => {
+  return 'Click the plus button or double click within the timeline to add a planned ' + props.type + '.<br />Click on a ' + props.type + " and then the 'x' button next to it to delete it."
+})
+
+const deleteDialogText = computed(() => {
+  if (deleteDialogItem) {
+    return 'Are you sure you want to delete planned ' + props.type + ' of ' + deleteDialogItem.value.className + ' on ' + props.parentKey + ' ' + deleteDialogItem.value.group + '?';
+  }
+  return 'Are you sure you want to delete this planned ' + props.parentKey + ' ' + props.type + '?';
+})
+
+const options = {
+  groupOrder: 'id',
+  stack: false,
+  maxHeight: '900px',
+  minHeight: '120px',
+  width: '1160px',
+  align: 'left',
+  dataAttributes: ['toggle', 'html'],
+  selectable: props.editable,
+  editable: props.editable,
+  zoomKey: 'ctrlKey',
+  tooltip: {
+    overflowMethod: 'cap'
+  },
+  onRemove: function (item, callback) {
+    deleteDialogItem.value = item;
+    deleteDialogCallback.value = callback;
+    deleteDialog.value = true;
+  },
+  onAdd: function (item, callback) {
+    item.status = 'AVAILABLE';
+    item.end = new Date(item.start);
+    item.end.setDate(item.start.getDate() + 1);
+    addDialogItem.value = item;
+    addDialogCallback.value = callback;
+    addDialog.value = true;
+  },
+};
+
+function onAddItem() {
+  var item = {status: 'AVAILABLE'};
+  addDialogItem.value = item;
+  addDialogCallback.value = null;
+  addDialog.value = true;
+}
+
+function toTooltip(item) {
+  let tooltip = '<h4>' + item.status + '</h4>';
+  if (item.reason) {
+    tooltip += '<br /><p>' + item.reason + '</p>';
+  }
+  if (item.optical_element_groups && Object.keys(item.optical_element_groups).length != 0) {
+    tooltip += '<br /><p>' + (JSON.stringify(item.optical_element_groups) || '') + '</p>';
+  }
+  if (item.operation_modes && Object.keys(item.operation_modes).length != 0) {
+    tooltip += '<br /><p>' + (JSON.stringify(item.operation_modes) || '') + '</p>';
+  }
+  return tooltip;
+}
+
+function setupVisItems() {
+  last_end = new Date();
+  if (apiItems.value) {
+    // Planned statues are in a list ordered by soonest first
+    apiItems.value.forEach(item => {
+      keySet.add(item[props.parentKey])
+      if (new Date(item.end) > last_end) {
+        last_end = new Date(item.end);
+      }
+      visItems.add({
+        group: item[props.parentKey],
+        start: item.start,
+        raw: item,
+        end: item.end,
+        className: item.status,
+        title: toTooltip(item),
+        editable: { updateTime: false, updateGroup: false, remove: props.editable },
+        toggle: 'tooltip',
+        html: true,
+        type: 'range'
+      });
+    })
+  }
+}
+
+function setupVisGroups() {
+  keySet.forEach(key => {
+    visGroups.add({
+      id: key,
+      content: '<a href=/' + props.parentKey + 's/' + key + ' >' + key + '</a>',
+      title: key
+    });
+  })
+}
+
+async function loadAPIItems () {
+  // Planned future items are only valid in the future, so cap query from now
+  let url = import.meta.env.VITE_HEROIC_URL + 'api/' + props.apiEndpoint + '/?limit=1000&end_after=' + props.start;
+  if (props.end) {
+    url += '&start_before=' + props.end;
+  }
+  if (props.telescopes && !props.editable) {
+    // Filter by telescope here
+    props.telescopes.forEach(telescope => {
+      url += '&telescope=' + telescope;
+    })
+  }
+  if (props.editable) {
+    userStore.profile.managed_observatories.forEach(observatory => {
+      url += '&observatory=' + observatory;
+    })
+  }
+  await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
+    apiItems.value = data.results;
+  }})
+}
+
+async function deleteAPIItem(id) {top
+  let url = import.meta.env.VITE_HEROIC_URL + 'api/' + props.apiEndpoint + '/' + id + '/';
+  const response = await fetchApiCall({url: url, method: 'DELETE', credentials: 'include'});
+  if (response && response.ok) {
+    return true;
+  }
+  return false;
+}
+
+async function createAPIItem (item) {
+  let url = import.meta.env.VITE_HEROIC_URL + 'api/' + props.apiEndpoint + '/';
+  const response = await fetchApiCall({url: url, method: 'POST', body: item, credentials: 'include'});
+  if (response) {
+    return response;
+  }
+  return null;
+}
+
+function timelineSetup() {
+  visItems.clear();
+  visGroups.clear();
+  keySet.clear();
+  setupVisItems();
+  setupVisGroups();
+  timeline.setData({items: visItems, groups: visGroups});
+  timeline.setWindow((new Date()).toISOString(), last_end.toISOString());
+}
+
+function timelineInitialization() {
+  timeline = new Timeline(timelineDiv.value, new DataSet([]), options);
+}
+
+async function deleteItem(item) {
+  if (item) {
+    let success = await deleteAPIItem(item.raw.id)
+    if (success) {
+      // remove from the already loaded list
+      apiItems.value = apiItems.value.filter(obj => obj.id !== item.raw.id);
+      deleteDialogCallback.value(item);
+    }
+  }
+  else {
+    deleteDialogCallback.value(null);
+  }
+
+  deleteDialog.value = false;
+}
+
+async function addItem(item) {
+  if (item) {
+    let apiItem = {
+      start: item.start,
+      end: item.end,
+      status: item.status
+    }
+    if (props.parentKey === 'telescope') {
+      apiItem.telescope = item.group;
+      apiItem.reason = item.reason || '';
+    }
+    else if (props.parentKey === 'instrument') {
+      apiItem.instrument = item.group;
+    }
+    let addedItem = await createAPIItem(apiItem)
+    if (addedItem) {
+      // If the group didn't exist before, add it to the timeline groups data here
+      if (!keySet.has(item.group)) {
+        keySet.add(item.group);
+        visGroups.add({
+          id: item.group,
+          content: '<a href=/' + props.parentKey + 's/' + item.group + ' >' + item.group + '</a>',
+          title: item.group
+        })
+      }
+      // Add the item to the already loaded list
+      apiItems.value.push(addedItem);
+      item.raw = addedItem;
+      item.className = addedItem.status;
+      item.title = toTooltip(addedItem);
+      item.editable = { updateTime: false, updateGroup: false, remove: props.editable };
+      item.toggle = 'tooltip';
+      item.html = true;
+      item.type=  'range';
+      delete item.content;
+      if (addDialogCallback.value) {
+        addDialogCallback.value(item);
+      }
+      else {
+        // In this case there was no callback from the timeline, so add the item to the timeline data here
+        visItems.add(item);
+      }
+    }
+  }
+  else if (addDialogCallback.value) {
+    addDialogCallback.value(null);
+  }
+  addDialog.value = false;
+}
+
+onMounted(async () => {
+  await loadAPIItems();
+  timelineInitialization();
+  timelineSetup();
+})
+
+watch([() => props.start, () => props.end, () => props.telescopes], async () => {
+  // When start/end date is changed, reload the planned data
+  await loadAPIItems();
+  timelineSetup();
+}, { deep: true })
+
+</script>
+<template>
+  <div class="mt-3">
+    <h1 align="center">{{ props.editable ? 'Manage ': ''}}Planned {{ capitalize(props.type) }}
+      <v-tooltip v-if="props.editable" location="bottom">
+        <template v-slot:activator="{ props }">
+          <v-icon v-bind="props" icon="mdi-information-variant" color="primary" size="x-small" class="info-button"></v-icon>
+        </template>
+        <span v-html="helpText"></span>
+      </v-tooltip>
+      <v-btn v-if="props.editable" icon="mdi-plus" variant="tonal" color="green" v-tooltip:bottom="'Add Planned ' + capitalize(props.type)" @click="onAddItem"></v-btn>
+    </h1>
+  </div>
+  <div ref="timelineDiv" class="ml-4 mt-3">
+  </div>
+  <v-dialog v-model="deleteDialog" width="auto">
+    <v-card max-width="600" :text="deleteDialogText" :title="'Delete Planned' + capitalize(props.type) + '?'">
+      <template v-slot:actions>
+        <v-btn text="No" variant="outlined" @click="deleteItem(null)"></v-btn>
+        <v-spacer></v-spacer>
+        <v-btn text="Delete" variant="outlined" @click="deleteItem(deleteDialogItem)"></v-btn>
+      </template>
+    </v-card>
+  </v-dialog>
+  <v-dialog v-model="addDialog" width="auto" height="80%">
+    <v-card width="600" :title="'Add Planned ' + capitalize(props.type)">
+      <v-card-text>
+        <v-row>
+          <v-col cols="6">
+            <v-label id="add-item-start-dp-label" class="datepicker-label">{{addDialogItem.start ? "Start Date": ""}}</v-label> 
+            <DatePicker v-model="addDialogItem.start" id="add-item-start-dt-picker" model-type="iso" placeholder="Start Date" label="Start" required dark></DatePicker>
+          </v-col>
+          <v-col cols="6">
+            <v-label id="add-item-end-dp-label" class="datepicker-label">{{addDialogItem.end ? "End Date": ""}}</v-label> 
+            <DatePicker v-model="addDialogItem.end" id="add-item-end-dt-picker" model-type="iso" placeholder="End Date" label="End" required dark></DatePicker>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="6">
+            <v-select v-model="addDialogItem.status" label="Status" :items="['SCHEDULABLE', 'AVAILABLE', 'UNAVAILABLE']" variant="outlined"></v-select>
+          </v-col>
+          <v-col cols="6">
+            <telescope-select v-if="props.parentKey === 'telescope'" v-model="addDialogItem.group" :multiple="false" :observatory-filter="userStore.profile.managed_observatories"></telescope-select>
+            <instrument-select v-if="props.parentKey === 'instrument'" v-model="addDialogItem.group" :multiple="false" :observatory-filter="userStore.profile.managed_observatories"></instrument-select>
+          </v-col>
+        </v-row>
+        <v-row v-if="props.parentKey === 'telescope'">
+          <v-col>
+            <v-textarea v-model="addDialogItem.reason" label="Reason" variant="outlined" rows="2"></v-textarea>
+          </v-col>
+        </v-row>
+      </v-card-text>
+      <template v-slot:actions>
+        <v-btn text="No" variant="outlined" @click="addItem(null)" class="ml-3"></v-btn>
+        <v-spacer></v-spacer>
+        <v-btn text="Add" variant="outlined"  @click="addItem(addDialogItem)" class="mr-3"></v-btn>
+      </template>
+    </v-card>
+  </v-dialog>
+  <status-timeline-legend class="ml-4" max-width="1160px"></status-timeline-legend>
+</template>
+<style>
+</style>

--- a/src/components/StatusTimeline.vue
+++ b/src/components/StatusTimeline.vue
@@ -3,22 +3,33 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { fetchApiCall } from '@/utils/api'
 import { useFiltersStore } from '@/stores/filters'
 import { DataSet, Timeline } from 'vis-timeline/standalone';
+import StatusTimelineLegend from '@/components/global/StatusTimelineLegend.vue';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';
-
+import "@/assets/timeline.css"
 
 const props = defineProps({
+  apiEndpoint: {
+    type: String,
+    required: true
+  },
   telescope: {
     type: String,
     required: true
+  },
+  instrument: {
+    type: String,
+    required: false
   }
 })
 
 const ONEDAY = 3600 * 1000 * 24;
 const filtersStore = useFiltersStore()
 const timelineDiv = ref(null);
-const telescopeStatuses = ref([]);
+const historicalItems = ref([]);
+const plannedItems = ref([]);
 const telescopeDarkIntervals = ref({});
 var timeline = null;
+
 const options = {
   groupOrder: 'id',
   stack: false,
@@ -30,12 +41,22 @@ const options = {
   selectable: false,
   zoomKey: 'ctrlKey',
   tooltip: {
-    overflowMethod: 'cap'
+    overflowMethod: 'flip'
   }
 };
 
-function statusTooltip(status) {
-  return '<h4>' + status.status + '</h4><br><p>' + (status.reason || '') + '</p>';
+function toTooltip(item) {
+  let tooltip = '<h4>' + item.status + '</h4>';
+  if (item.reason) {
+    tooltip += '<br /><p>' + item.reason + '</p>';
+  }
+  if (item.optical_element_groups && Object.keys(item.optical_element_groups).length != 0) {
+    tooltip += '<br /><pre>' + (JSON.stringify(item.optical_element_groups, null, 2) || '') + '</pre>';
+  }
+  if (item.operation_modes && Object.keys(item.operation_modes).length != 0) {
+    tooltip += '<br /><pre>' + (JSON.stringify(item.operation_modes, null, 2) || '') + '</pre>';
+  }
+  return tooltip;
 }
 
 const start = computed(() => {
@@ -56,17 +77,17 @@ const endPlusOne = computed(() => {
 
 const timelineData = computed(() => {
   let visData = new DataSet();
-  if (telescopeStatuses.value) {
-    var lastStatus;
+  if (historicalItems.value) {
+    var lastItem;
     // Statues are in a list ordered by soonest first
-    telescopeStatuses.value.forEach(status => {
-      if (lastStatus) {
+    historicalItems.value.forEach(item => {
+      if (lastItem) {
         visData.add({
           group: 'status',
-          start: status.date,
-          end: lastStatus.date,
-          className: status.status,
-          title: statusTooltip(status),
+          start: item.date,
+          end: lastItem.date,
+          className: item.status,
+          title: toTooltip(item),
           toggle: 'tooltip',
           html: true,
           type: 'range'
@@ -75,16 +96,36 @@ const timelineData = computed(() => {
       else {
         visData.add({
           group: 'status',
-          start: status.date,
+          start: item.date,
           end: end.value,
-          className: status.status,
-          title: statusTooltip(status),
+          className: item.status,
+          title: toTooltip(item),
           toggle: 'tooltip',
           html: true,
           type: 'range'
         });
       }
-      lastStatus = status;
+      lastItem = item;
+    })
+  }
+  // Layer the planned future items over the top of the last current item
+  if (plannedItems.value) {
+    // Planned statues are in a list ordered by soonest first
+    plannedItems.value.forEach(item => {
+      let capped_start = new Date(item.start);
+      if (capped_start < new Date()) {
+        capped_start = new Date();
+      }
+      visData.add({
+        group: 'status',
+        start: capped_start.toISOString(),
+        end: item.end,
+        className: item.status,
+        title: toTooltip(item),
+        toggle: 'tooltip',
+        html: true,
+        type: 'range'
+      });
     })
   }
   if (telescopeDarkIntervals.value && telescopeDarkIntervals.value[props.telescope]) {
@@ -128,10 +169,10 @@ const timelineData = computed(() => {
 
 const timelineGroups = computed(() => {
   let plotGroups = new DataSet();
-  if (telescopeStatuses.value){
+  if (historicalItems.value || plannedItems.value){
     plotGroups.add({
       id: 'status',
-      content: 'Status',
+      content: props.instrument ? 'Instrument Status': 'Telescope Status',
       title: 'status'
     });
   }
@@ -145,11 +186,31 @@ const timelineGroups = computed(() => {
   return plotGroups;
 })
 
-async function loadTelescopeStatus () {
-  const url = import.meta.env.VITE_HEROIC_URL + 'api/telescope-statuses' + '/?limit=1000&telescope=' + props.telescope + '&start=' + start.value + '&end=' + end.value;
+async function loadHistoricalAPIItems () {
+  let url = import.meta.env.VITE_HEROIC_URL + 'api/' + props.apiEndpoint + '/?limit=1000&telescope=' + props.telescope + '&start=' + start.value + '&end=' + end.value;
+  if (props.instrument) {
+    url += '&instrument=' + props.instrument;
+  }
   await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
-    telescopeStatuses.value = data.results;
+    historicalItems.value = data.results;
   }})
+}
+
+async function loadPlannedAPIItems () {
+  // Planned future items is only valid in the future, so cap query from now
+  if (new Date(end.value) > new Date()) {
+    let capped_start = new Date(start.value);
+    if (capped_start < new Date()) {
+      capped_start = new Date();
+    }
+    let url = import.meta.env.VITE_HEROIC_URL + 'api/planned-' + props.apiEndpoint + '/?limit=1000&telescope=' + props.telescope + '&end_after=' + capped_start.toISOString() + '&start_before=' + end.value;
+    if (props.instrument) {
+      url += '&instrument=' + props.instrument;
+    }
+    await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {
+      plannedItems.value = data.results;
+    }})
+  }
 }
 
 async function loadTelescopeDarkIntervals () {
@@ -167,55 +228,32 @@ onMounted(async () => {
   timelineSetup();
 })
 
-watch(() => filtersStore.$state.visibilityResults, async () => {
-  await loadTelescopeStatus();
-  await loadTelescopeDarkIntervals();
-  timeline.setGroups(new DataSet([]));
-  timeline.setItems(new DataSet([]));
-  timeline.setGroups(timelineGroups.value);
-  timeline.setItems(timelineData.value);
-  timeline.setWindow(start.value, end.value);
-}, {immediate: true})
-
-watch(() => filtersStore.$state.visibilityErrors, async () => {
-  if (Object.keys(filtersStore.$state.visibilityErrors).length > 0){
-    await loadTelescopeStatus();
+watch([() => filtersStore.queryParams.base.start, () => filtersStore.queryParams.base.end, () => props.telescope, () => props.instrument], async () => {
+  // When start/end date is changed or prop telescope is changed, reload telescope status
+  if (props.telescope) {
+    await loadHistoricalAPIItems();
+    await loadPlannedAPIItems();
     await loadTelescopeDarkIntervals();
     timeline.setGroups(new DataSet([]));
     timeline.setItems(new DataSet([]));
     timeline.setGroups(timelineGroups.value);
     timeline.setItems(timelineData.value);
+    timeline.setWindow(start.value, end.value);
   }
+}, {immediate: true})
+
+watch([() => filtersStore.$state.visibilityErrors, () => filtersStore.$state.visibilityResults], async () => {
+  timeline.setGroups(new DataSet([]));
+  timeline.setItems(new DataSet([]));
+  timeline.setGroups(timelineGroups.value);
+  timeline.setItems(timelineData.value);
+  timeline.setWindow(start.value, end.value);
 })
 
 </script>
 <template>
   <div ref="timelineDiv"></div>
+  <status-timeline-legend :include-visibility="true" :include-sun="true" max-width="1160px" style="width: 100%"></status-timeline-legend>
 </template>
 <style>
-.vis-time-axis .vis-text {
-  color: #b3b3b3 !important;
-}
-.vis-labelset .vis-label {
-  color: #b3b3b3 !important;
-}
-.vis-item.VISIBLE {
-  background-color: rgb(185, 115, 234);
-  border-color: rgb(167, 71, 234);
-}
-.vis-item.AVAILABLE {
-  background-color: lightblue;
-  border-color: lightblue;
-}
-.vis-item.UNAVAILABLE {
-  background-color: lightcoral;
-  border-color: lightcoral;
-}
-.vis-item.SCHEDULABLE {
-  background-color: lightgreen;
-  border-color: lightgreen;
-}
-.vis-item.sun-up {
-  background-color: lightyellow !important;
-}
 </style>

--- a/src/components/global/GlobalFilters.vue
+++ b/src/components/global/GlobalFilters.vue
@@ -7,7 +7,7 @@ import TelescopeSelect from './TelescopeSelect.vue'
 import { watchDebounced } from '@vueuse/core';
 
 const drawer = ref(true)
-const rail = ref(true)
+const rail = ref(false)
 const searchTargetErrors = ref();
 const searchTargetSuccess = ref();
 const filtersStore = useFiltersStore()
@@ -177,7 +177,7 @@ watchDebounced(() => filtersStore.$state.queryParams, () => {
   if (dateClass.value == 'fields-complete' && targetClass.value == 'fields-complete') {
     filtersStore.queryVisibilityAndAirmass();
   }
-}, { debounce: 500, deep: true, immediate: true })
+}, { debounce: 500, deep: true})
 
 
 </script>
@@ -187,14 +187,14 @@ watchDebounced(() => filtersStore.$state.queryParams, () => {
     v-model="drawer"
     :rail="rail"
     :location="$vuetify.display.mobile ? 'bottom' : undefined"
-    width="512"
+    width="504"
     permanent
     @click="rail = false"
   >
     <v-list-item variant="outlined" nav>
       <v-list-item-title>
         <v-row>
-          <v-col cols="3" style="font-size:1.2rem;">Filters</v-col>
+          <v-col cols="3" style="font-size:1.2rem;">{{ rail ? '': 'Filters' }}</v-col>
           <v-col cols="3" offset="1" style="min-height: 44px;" v-if="!rail">
             Visibility:
             <v-progress-circular v-if="filtersStore.loadingVisibility" class="ml-1" color="primary" size="18" indeterminate></v-progress-circular>
@@ -213,7 +213,7 @@ watchDebounced(() => filtersStore.$state.queryParams, () => {
       </v-list-item-title>
       <template v-slot:append>
         <v-btn
-          class="menu-chevron"
+          :class="rail ? 'menu-chevron-collapsed': 'menu-chevron'"
           :icon="rail ? 'mdi-chevron-right': 'mdi-chevron-left'"
           variant="text"
           @click.stop="rail = !rail"
@@ -547,6 +547,20 @@ watchDebounced(() => filtersStore.$state.queryParams, () => {
             :step="1"
           >
           </v-number-input>
+          <v-switch
+            label="Filter out Past Unavailability"
+            v-model="filtersStore.queryParams.base.include_status"
+            density="comfortable"
+            style="height: 44px;"
+            color="secondary">
+          </v-switch>
+          <v-switch
+            label="Filter out Future Unavailability"
+            v-model="filtersStore.queryParams.base.include_planned_status"
+            density="comfortable"
+            style="height: 44px;"
+            color="secondary">
+          </v-switch>
         </v-expansion-panel-text>
       </v-expansion-panel>
       <v-expansion-panel>
@@ -561,7 +575,7 @@ watchDebounced(() => filtersStore.$state.queryParams, () => {
           </v-row>        
         </v-expansion-panel-title>
         <v-expansion-panel-text class="filter-panel">
-          <telescope-select></telescope-select>
+          <telescope-select class="mt-6" v-model="filtersStore.queryParams.base.telescopes" :include-tooltip="true"></telescope-select>
         </v-expansion-panel-text>
       </v-expansion-panel>
     </v-expansion-panels>
@@ -569,8 +583,12 @@ watchDebounced(() => filtersStore.$state.queryParams, () => {
 </template>
 <style scoped>
 
+.menu-chevron-collapsed {
+  left: -45px;
+}
+
 .menu-chevron {
-  left: -6px;
+  left: -4px;
 }
 
 .fields-complete {

--- a/src/components/global/InstrumentSelect.vue
+++ b/src/components/global/InstrumentSelect.vue
@@ -23,69 +23,83 @@ const props = defineProps({
 
 const tooltip = computed(() => {
   if (props.includeTooltip) {
-    return 'Optional filter on Telescopes';
+    return 'Optional filter on Instruments';
   }
   return null;
 })
 
-const telescopesByObservatory = computed(() => {
+const instrumentsByObservatory = computed(() => {
   if (filtersStore.telescopes){
-    let telescopes = {};
+    let instruments = {};
     Object.values(filtersStore.telescopes).forEach(telescope => {
       if (!props.observatoryFilter || props.observatoryFilter.includes(telescope.observatory)) {
         let observatory = telescope.observatory + ': ' + telescope.observatory_name;
         let site = telescope.id.split('.')[1] + ': ' + telescope.site_name;
-        if (!(observatory in telescopes)){
-          telescopes[observatory] = {};
+        if (!(observatory in instruments)){
+          instruments[observatory] = {};
         }
-        if (!(site in telescopes[observatory])) {
-          telescopes[observatory][site] = [];
+        if (!(site in instruments[observatory])) {
+          instruments[observatory][site] = {};
         }
-        telescopes[observatory][site].push({
-          'id': telescope.id,
-          'telescope': telescope.id.split('.')[2],
-          'name': telescope.name,
-          'site': telescope.site,
-          'observatory': observatory
+        telescope.instruments.forEach(instrument => {
+          let tel_id = telescope.id.split('.')[2] + ': ' + telescope.name;
+          if (!(tel_id in instruments[observatory][site])) {
+            instruments[observatory][site][tel_id] = []
+          }
+          instruments[observatory][site][tel_id].push({
+            'id': instrument.id,
+            'instrument': instrument.id.split('.')[3],
+            'name': instrument.name,
+            'telescope': telescope.id.split('.')[2],
+            'site': telescope.site,
+            'observatory': telescope.observatory
+          })
         })
       }
     })
-    return telescopes;
+    return instruments;
   }
-  return [];
+  return {};
 })
 
-const telescopeOptions = computed(() => {
-  const telescopes = telescopesByObservatory.value;
-  let telescopeItems = [];
-  for (const [observatory, sites] of Object.entries(telescopes)) {
-    telescopeItems.push({
+const instrumentOptions = computed(() => {
+  const instruments = instrumentsByObservatory.value;
+  let instrumentItems = [];
+  for (const [observatory, sites] of Object.entries(instruments)) {
+    instrumentItems.push({
       props: {observatory: observatory}
     });
     for (const [site, telescopes] of Object.entries(sites)) {
-      telescopeItems.push({
+      instrumentItems.push({
         props: {site: site}
       });
-      telescopeItems.push(...telescopes);
-      telescopeItems.push({
+      for (const [telescope, instruments] of Object.entries(telescopes)) {
+        instrumentItems.push({
+          props: {telescope: telescope}
+        });
+        instrumentItems.push(...instruments);
+      }
+      instrumentItems.push({
         props: { divider: true}
       });
     }
   }
-  return telescopeItems;
+  return instrumentItems;
 })
 
 const indeterminateStates = computed(() => {
   let states = {};
-  const telescopes = telescopesByObservatory.value;
-  for (const observatory of Object.keys(telescopes)) {
+  const instruments = instrumentsByObservatory.value;
+  for (const observatory of Object.keys(instruments)) {
     let numSelected = 0;
     let totalNum = 0;
-    for (const site of Object.values(telescopes[observatory])) {
-      for (const telescope of site) {
-        totalNum += 1;
-        if (model.value && model.value.includes(telescope.id)) {
-          numSelected += 1;
+    for (const site of Object.values(instruments[observatory])) {
+      for (const telescope of Object.values(instruments[observatory][site])) {
+        for (const instrument of telescope) {
+          totalNum += 1;
+          if (model.value && model.value.includes(instrument.id)) {
+            numSelected += 1;
+          }
         }
       }
     }
@@ -100,20 +114,22 @@ const indeterminateStates = computed(() => {
 })
 
 async function selectAllObservatory(selected, observatory) {
-  const telescopes = telescopesByObservatory.value;
-  if (telescopes[observatory]) {
+  const instruments = instrumentsByObservatory.value;
+  if (instruments[observatory]) {
     if (model.value == null) {
       model.value = [];
       await nextTick();
     }
-    for (const site of Object.values(telescopes[observatory])) {
-      for (const telescope of site) {
-        let index = model.value.indexOf(telescope.id);
-        if (selected && index == -1) {
-          model.value.push(telescope.id);
-        }
-        else if (!selected && index > -1) {
-          model.value.splice(index, 1);
+    for (const site of Object.values(instruments[observatory])) {
+      for (const telescope of Object.values(instruments[observatory][site])) {
+        for (const instrument of telescope) {
+          let index = model.value.indexOf(instrument.id);
+          if (selected && index == -1) {
+            model.value.push(instrument.id);
+          }
+          else if (!selected && index > -1) {
+            model.value.splice(index, 1);
+          }
         }
       }
     }
@@ -129,10 +145,10 @@ async function selectAllObservatory(selected, observatory) {
   <v-select
     variant="outlined"
     v-model="model"
-    :items="telescopeOptions"
+    :items="instrumentOptions"
     item-value="id"
-    item-title="telescope"
-    label="Telescopes"
+    item-title="instrument"
+    label="Instruments"
     v-tooltip:top="tooltip"
     :chips="props.multiple"
     closable-chips
@@ -155,6 +171,9 @@ async function selectAllObservatory(selected, observatory) {
       </v-list-subheader>
       <v-list-subheader v-else-if="data.props.site">
         {{ data.props.site }}
+      </v-list-subheader>
+      <v-list-subheader v-else-if="data.props.telescope">
+        {{ data.props.telescope }}
       </v-list-subheader>
       <v-divider v-else-if="data.props.divider" />
       <v-list-item v-else v-bind="data.props" class="pl-6">

--- a/src/components/global/NavBar.vue
+++ b/src/components/global/NavBar.vue
@@ -168,7 +168,7 @@ onMounted(async () => {
 }
 
 .navbar-item {
-  width: 200px;
+  width: 180px;
   text-align:center;
 }
 

--- a/src/components/global/NavBar.vue
+++ b/src/components/global/NavBar.vue
@@ -1,11 +1,15 @@
 <script setup>
-import { onMounted, ref} from 'vue';
+import { onMounted, ref, computed} from 'vue';
 import { RouterLink } from 'vue-router'
 import { useUserStore } from '@/stores/user';
 import { fetchApiCall } from '@/utils/api'
 
 const userStore = useUserStore()
 const revokeTokenDialog = ref(false);
+
+const userManagesObservatories = computed(() => {
+  return userStore.loggedIn && userStore.profile && userStore.profile.managed_observatories;
+})
 
 function login() {
   // Login is a multi-step process through Hop-admin, so set a flag here so we know we are in the middle of a login process
@@ -96,11 +100,19 @@ onMounted(async () => {
         Instruments
       </router-link>
       <router-link
-        to="/about"
+        to="/planning"
         class="navbar-item"
       >
-        <v-icon class="pr-2 pb-1" icon="mdi-help" size="small"></v-icon>
-        About
+        <v-icon class="pr-2 pb-1" icon="mdi-calendar" size="small"></v-icon>
+        Planning
+      </router-link>
+      <router-link
+        v-if="userManagesObservatories"
+        to="/planning-management"
+        class="navbar-item"
+      >
+        <v-icon class="pr-2 pb-1" icon="mdi-calendar" size="small"></v-icon>
+        Planning Management
       </router-link>
       <v-menu>
         <template v-slot:activator="{ props }">

--- a/src/components/global/StatusTimelineLegend.vue
+++ b/src/components/global/StatusTimelineLegend.vue
@@ -1,0 +1,79 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  includeVisibility: {
+    type: Boolean,
+    default: false
+  },
+  includeSun: {
+    type: Boolean,
+    default: false
+  },
+  maxWidth: {
+    type: String,
+    default: "800px"
+  }
+})
+
+const baseLegendItems = {
+  AVAILABLE: 'Available',
+  SCHEDULABLE: 'Queue Schedulable',
+  UNAVAILABLE: 'Not Available',
+}
+
+const legendItems = computed(() => {
+  var items = {...baseLegendItems};
+  if (props.includeVisibility) {
+    items.VISIBLE = 'Target Visible';
+  }
+  if (props.includeSun) {
+    items.SUNUP = 'Sun Up';
+  }
+  return items;
+})
+
+</script>
+<template>
+  <div class="timeline-legend">
+    <v-list class="d-flex flex-row justify-center dark-background" variant="text" :max-width="props.maxWidth">
+        <v-list-item v-for="(text, className) in legendItems">
+            <span class="legend-item mb-1 mr-1" :class="className"></span>
+            {{ text }}
+        </v-list-item>
+      </v-list>
+  </div>
+</template>
+<style>
+
+.dark-background {
+  background: var(--v-theme-background);
+}
+
+.legend-item {
+    width: 18px;
+    height: 12px;
+    display: inline-block;
+    vertical-align: middle !important;
+}
+
+.VISIBLE {
+  background-color: rgb(185, 115, 234);
+  border-color: rgb(167, 71, 234);
+}
+.AVAILABLE {
+  background-color: cyan;
+  border-color: cyan;
+}
+.UNAVAILABLE {
+  background-color: coral;
+  border-color: coral;
+}
+.SCHEDULABLE {
+  background-color: lightgreen;
+  border-color: lightgreen;
+}
+.SUNUP {
+  background-color: lightyellow !important;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -50,6 +50,16 @@ const router = createRouter({
         title: 'Telescope Detail'
       }
     },
+    {
+      path: "/planning",
+      name: "planning",
+      component: () => import("../views/PlanningView.vue"),
+    },
+    {
+      path: "/planning-management",
+      name: "planning-management",
+      component: () => import("../views/PlanningManagementView.vue"),
+    },
   ],
 });
 

--- a/src/stores/filters.js
+++ b/src/stores/filters.js
@@ -6,16 +6,18 @@ export const useFiltersStore = defineStore("filters", {
     return {
       queryParams: {
         base: {
-          start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days ago
-          end: new Date().toISOString(), // Now
-          telescopes: ['ligo.hanford.h1', 'ligo.livingston.l1', 'virgo.cascina.v1', 'kagra.kamioka.k1'], // All GW detectors
+          start: null,
+          end: null,
+          telescopes: null,
           max_airmass: 2.0,
           min_lunar_distance: 0.0,
           max_lunar_phase: 1.0,
+          include_status: false,
+          include_planned_status: true
         },
         siderealTarget: {
-          ra: 197.450375, // NGC 4993 (host of GW170817)
-          dec: -23.38148,  // NGC 4993 (host of GW170817)
+          ra: null,
+          dec: null,
           proper_motion_ra: null,
           proper_motion_dec: null,
           epoch: 2000.0,
@@ -37,7 +39,7 @@ export const useFiltersStore = defineStore("filters", {
       },
       telescopes: null,
       filteredTelescopes: [],
-      targetName: 'NGC 4993',  // Default to NGC 4993 (GW170817 host)
+      targetName: null,
       targetType: 'SIDEREAL',
       nonSiderealType: null,
       visibilityAbort: null,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -38,6 +38,7 @@ async function fetchApiCall({ url, method, body = null, header, signal = null, c
     // ok response but empty content
     if (response.ok && (!response.headers.has('content-length') || response.headers.get('content-length') == 0)) {
       successCallback ? successCallback(null) : null
+      return response
     } else {
       const responseData = await response.json()
       if (!response.ok) {
@@ -50,6 +51,7 @@ async function fetchApiCall({ url, method, body = null, header, signal = null, c
     }
   } catch (error) {
     failCallback ? failCallback(error) : null
+    return null
   }
 }
   
@@ -59,4 +61,8 @@ const handleError = (response) => {
   console.error('API call failed with error:', error)
 }
 
-export { fetchApiCall, handleError }
+const capitalize = (str) => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export { fetchApiCall, handleError, capitalize }

--- a/src/views/InstrumentDetailsView.vue
+++ b/src/views/InstrumentDetailsView.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router';
 import { useFiltersStore } from '@/stores/filters'
-
+import StatusTimeline from '@/components/StatusTimeline.vue';
 
 const filtersStore = useFiltersStore()
 
@@ -80,6 +80,9 @@ const telescopeData = computed(() => {
           </tr>
         </tbody>
       </v-table>
+    </v-row>
+    <v-row class="ml-2 mt-6">
+      <status-timeline api-endpoint="instrument-capabilities" :telescope="telescopeData.id || ''" :instrument="route.params.id"></status-timeline>
     </v-row>
   </v-container>
 </template>

--- a/src/views/PlanningManagementView.vue
+++ b/src/views/PlanningManagementView.vue
@@ -1,0 +1,12 @@
+<script setup>
+import PlannedTimeline from '@/components/PlannedTimeline.vue';
+
+</script>
+<template>
+  <planned-timeline type="status" parent-key="telescope" api-endpoint="planned-telescope-statuses" :editable="true"></planned-timeline>
+  <br />
+  <planned-timeline type="capability" parent-key="instrument" api-endpoint="planned-instrument-capabilities" :editable="true"></planned-timeline>
+</template>
+<style>
+
+</style>

--- a/src/views/PlanningView.vue
+++ b/src/views/PlanningView.vue
@@ -1,0 +1,31 @@
+<script setup>
+import PlannedTimeline from '@/components/PlannedTimeline.vue';
+import { useFiltersStore } from '@/stores/filters'
+
+const filtersStore = useFiltersStore()
+
+</script>
+<template>
+  <planned-timeline
+    type="status"
+    parent-key="telescope"
+    api-endpoint="planned-telescope-statuses"
+    :editable="false"
+    :start="filtersStore.queryParams.base.start || (new Date()).toISOString()"
+    :end="filtersStore.queryParams.base.end || null"
+    :telescopes="filtersStore.queryParams.base.telescopes"
+  ></planned-timeline>
+  <br />
+  <planned-timeline
+    type="capability"
+    parent-key="instrument"
+    api-endpoint="planned-instrument-capabilities"
+    :editable="false"
+    :start="filtersStore.queryParams.base.start || (new Date()).toISOString()"
+    :end="filtersStore.queryParams.base.end || null"
+    :telescopes="filtersStore.queryParams.base.telescopes"
+    ></planned-timeline>
+</template>
+<style>
+
+</style>

--- a/src/views/TelescopeDetailsView.vue
+++ b/src/views/TelescopeDetailsView.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router';
 import { useFiltersStore } from '@/stores/filters'
-import TelescopeStatusTimeline from '@/components/TelescopeStatusTimeline.vue'
+import StatusTimeline from '@/components/StatusTimeline.vue';
 
 const filtersStore = useFiltersStore()
 
@@ -109,11 +109,8 @@ function generateItemLink(item) {
         </v-row>
       </v-col>
     </v-row>
-    <v-row>
-      <telescope-status-timeline
-        :telescope="route.params.id"
-        class="pt-4 pl-4"
-      ></telescope-status-timeline>
+    <v-row class="ml-2 mt-6">
+      <status-timeline api-endpoint="telescope-statuses" :telescope="route.params.id"></status-timeline>
     </v-row>
   </v-container>
 </template>


### PR DESCRIPTION
…rontend bugs

Additions:
- "Planning" view that responds to your selections of date ranges in the future and telescopes, and shows the planned statuses for those telescopes and planned capabilities for their instruments
- "Planning Management" view that only observatory managers can see. Shows all the current planned statuses for telescopes/instruments under their observatory. Allows creation of new statuses and empty (status only) capabilities, and allows their deletion
- Added two more flags to constraints section of visibility filters, specifying if you want to include past or future telescope/instrument status into your visibility results
- Integrated planned future telescope status and instrument capability status into the Telescope and Instrument details pages when date ranges are set into the future

Fixes:
- Removed the erroneous filter presets that were merged
- Auto open the filters tab on page load so it is more obvious they should be filled out
- Some css fixes to the filters and telescope selection
- Added tab icon and title for the application

[heroic_planned_status_demo.webm](https://github.com/user-attachments/assets/af3b62eb-ca57-4dcc-b533-e3123cf278b7)
