### PR TITLE
fix: export FRONTEND_IMAGE in deploy scripts to prevent fallback to s…

### DIFF
--- a/.github/workflows/deploy_frontend_dev.yml
+++ b/.github/workflows/deploy_frontend_dev.yml
@@ -65,7 +65,7 @@ jobs:
               "GHCR_TOKEN=${GHCR_TOKEN} GHCR_ACTOR=${GHCR_ACTOR} bash -se" <<'REMOTE'
           set -e
           DEPLOY_PATH="/home/exouser/heroic-frontend"
-          FRONTEND_IMAGE="ghcr.io/scimma/heroic-frontend:dev"
+          export FRONTEND_IMAGE="ghcr.io/scimma/heroic-frontend:dev"
 
           cd "$DEPLOY_PATH"
 

--- a/.github/workflows/deploy_frontend_prod.yml
+++ b/.github/workflows/deploy_frontend_prod.yml
@@ -72,7 +72,7 @@ jobs:
               "GHCR_TOKEN=${GHCR_TOKEN} GHCR_ACTOR=${GHCR_ACTOR} VERSION=${VERSION} bash -se" <<'REMOTE'
           set -e
           DEPLOY_PATH="/home/exouser/heroic-frontend"
-          FRONTEND_IMAGE="ghcr.io/scimma/heroic-frontend:${VERSION}"
+          export FRONTEND_IMAGE="ghcr.io/scimma/heroic-frontend:${VERSION}"
 
           cd "$DEPLOY_PATH"
 


### PR DESCRIPTION
…tale local image

Fix: `docker compose up -d` was silently falling back to a stale local `heroic-frontend:latest` image because `FRONTEND_IMAGE` wasn't reliably inherited across separate prefixed commands.